### PR TITLE
A couple of small API changes

### DIFF
--- a/Sources/Converse/ContentBlocks/ToolResultBlock.swift
+++ b/Sources/Converse/ContentBlocks/ToolResultBlock.swift
@@ -71,7 +71,7 @@ public struct ToolResultBlock: Codable, Sendable {
     }
 
     /// convenience initializer for ToolResultBlock for any Codable
-    public init<T: Codable>(_ object: T, id: String, status: Status? = .success) throws {
+    public init<T: Encodable>(_ object: T, id: String, status: Status? = .success) throws {
         guard let data = try? JSONEncoder().encode(object) else {
             throw BedrockLibraryError.encodingError("Could not encode object to JSON")
         }

--- a/Sources/Converse/ConverseRequestBuilder.swift
+++ b/Sources/Converse/ConverseRequestBuilder.swift
@@ -286,7 +286,7 @@ public struct ConverseRequestBuilder {
         return try self.withToolResult(toolResult)
     }
 
-    public func withToolResult<C: Codable>(
+    public func withToolResult<C: Encodable>(
         _ object: C,
         id: String? = nil,
         status: ToolResultBlock.Status? = nil

--- a/Sources/Converse/Tool.swift
+++ b/Sources/Converse/Tool.swift
@@ -22,7 +22,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
-public struct Tool: Codable, CustomStringConvertible {
+public struct Tool: Codable, CustomStringConvertible, Sendable {
     public let name: String
     public let inputSchema: JSON
     public let toolDescription: String?


### PR DESCRIPTION
While working on a demo fro the AWS re:Invent conference, I found a set of minor usability changes to be required.

- `ToolResultBlock` should not be created from `any Codable` but just `any Encodable` 
- `Tool` must be Sendable to be shared between isolation contexts