### PR TITLE
[fix] JSON encoding did not remove the top level "value"

### DIFF
--- a/Sources/Converse/ContentBlocks/JSON.swift
+++ b/Sources/Converse/ContentBlocks/JSON.swift
@@ -189,5 +189,9 @@ public struct JSON: Codable, Sendable {
         let container = try decoder.singleValueContainer()
         value = try container.decode(JSONValue.self)
     }
+    
+    public func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
 
 }

--- a/Sources/Converse/ContentBlocks/JSON.swift
+++ b/Sources/Converse/ContentBlocks/JSON.swift
@@ -189,7 +189,7 @@ public struct JSON: Codable, Sendable {
         let container = try decoder.singleValueContainer()
         value = try container.decode(JSONValue.self)
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         try value.encode(to: encoder)
     }

--- a/Tests/Converse/ConverseToolTests.swift
+++ b/Tests/Converse/ConverseToolTests.swift
@@ -36,7 +36,7 @@ extension BedrockServiceTests {
         if let toolUse = reply.toolUse {
             #expect(toolUse.id == "toolId")
             #expect(toolUse.name == "toolName")
-            #expect(toolUse.input["value"]?["code"] == "string")
+            #expect(toolUse.input["code"] == "string")
         } else {
             Issue.record("Tool use is nil")
         }
@@ -64,7 +64,7 @@ extension BedrockServiceTests {
             print(toolUse)
             #expect(toolUse.id == "toolId")
             #expect(toolUse.name == "toolName")
-            #expect(toolUse.input["value"]?["code"] == "string")
+            #expect(toolUse.input["code"] == "string")
         } else {
             Issue.record("ToolUse is nil")
         }

--- a/Tests/Converse/JSONTests.swift
+++ b/Tests/Converse/JSONTests.swift
@@ -13,6 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import Testing
 
 @testable import BedrockService
@@ -124,6 +125,23 @@ struct JSONTests {
         #expect(json["name"] == "Jane Doe")
         #expect(json["age"] == 30)
         #expect(json["isMember"] == true)
+    }
+
+    @Test("JSON encoding skips value wrapper")
+    func jsonEncodingSkipsValueWrapper() throws {
+        let json = JSON(with: .object(["test": .string("my_test")]))
+        let encoded = try JSONEncoder().encode(json)
+        let jsonString = String(data: encoded, encoding: .utf8)!
+        #expect(jsonString == "{\"test\":\"my_test\"}")
+        #expect(!jsonString.contains("\"value\":"))
+    }
+
+    @Test("JSON decoding skips value wrapper")
+    func jsonDecodingSkipsValueWrapper() throws {
+        let jsonString = "{\"test\":\"my_test\"}"
+        let data = jsonString.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(JSON.self, from: data)
+        #expect(decoded["test"] == "my_test")
     }
 }
 


### PR DESCRIPTION
The JSON encoding of JSON (for tool use) did not remove the top-level "value" container.

I added two tests to verify this will not happen again.