### PR TITLE
Add support for Claude Opus 4.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,11 @@ let package = Package(
         .library(name: "BedrockService", targets: ["BedrockService"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2"),
-        .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.6.3"),
-        .package(url: "https://github.com/smithy-lang/smithy-swift", from: "0.173.0"),
+        // use an old version until https://github.com/awslabs/aws-crt-swift/issues/373 will be resolved.
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
+        // .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0"),
+        .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.6.50"),
+        .package(url: "https://github.com/smithy-lang/smithy-swift", from: "0.181.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.4"),
         .package(url: "https://github.com/awslabs/aws-crt-swift", from: "0.54.2"),
     ],

--- a/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
@@ -251,4 +251,20 @@ extension BedrockModel {
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
+    public static let claude_opus_v4_6: BedrockModel = BedrockModel(
+        id: "anthropic.claude-opus-4-6-v1",
+        name: "Claude Opus v4.6",
+        modality: Claude_Opus_v4_6(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 128_000, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 0.999),
+                topK: Parameter(.topK, minValue: 0, maxValue: 500, defaultValue: 0),
+                stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
+                maxPromptSize: 200_000
+            ),
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning],
+            maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
+        )
+    )
 }

--- a/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
@@ -112,3 +112,52 @@ struct Claude_Opus_v4_5: TextModality, ConverseModality, ConverseStreamingModali
         try anthropicText.getTextResponseBody(from: data)
     }
 }
+
+struct Claude_Opus_v4_6: TextModality, ConverseModality, ConverseStreamingModality,
+    GlobalCrossRegionInferenceModality
+{
+    private let anthropicText: AnthropicText
+
+    let converseParameters: ConverseParameters
+    let converseFeatures: [ConverseFeature]
+
+    init(parameters: TextGenerationParameters, features: [ConverseFeature], maxReasoningTokens: Parameter<Int>) {
+        self.anthropicText = AnthropicText(
+            parameters: parameters,
+            features: features,
+            maxReasoningTokens: maxReasoningTokens
+        )
+        self.converseParameters = anthropicText.converseParameters
+        self.converseFeatures = anthropicText.converseFeatures
+    }
+
+    func getName() -> String { anthropicText.getName() }
+    func getParameters() -> TextGenerationParameters { anthropicText.getParameters() }
+    func getConverseParameters() -> ConverseParameters { anthropicText.getConverseParameters() }
+    func getConverseFeatures() -> [ConverseFeature] { anthropicText.getConverseFeatures() }
+
+    func getTextRequestBody(
+        prompt: String,
+        maxTokens: Int?,
+        temperature: Double?,
+        topP: Double?,
+        topK: Int?,
+        stopSequences: [String]?,
+        serviceTier: ServiceTier
+    ) throws -> BedrockBodyCodable {
+        try anthropicText.getTextRequestBody(
+            prompt: prompt,
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            stopSequences: stopSequences,
+            serviceTier: serviceTier
+        )
+    }
+
+    func getTextResponseBody(from data: Data) throws -> ContainsTextCompletion {
+        try anthropicText.getTextResponseBody(from: data)
+    }
+}
+

--- a/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
@@ -160,4 +160,3 @@ struct Claude_Opus_v4_6: TextModality, ConverseModality, ConverseStreamingModali
         try anthropicText.getTextResponseBody(from: data)
     }
 }
-

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -83,6 +83,8 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
             self = BedrockModel.claude_sonnet_v4_5
         case BedrockModel.claude_opus_v4_5.id:
             self = BedrockModel.claude_opus_v4_5
+        case BedrockModel.claude_opus_v4_6.id:
+            self = BedrockModel.claude_opus_v4_6
         // titan
         case BedrockModel.titan_text_g1_premier.id:
             self = BedrockModel.titan_text_g1_premier


### PR DESCRIPTION
This PR adds support for Anthropic's Claude Opus 4.6 model to the Bedrock service library.

### Changes

- Added `claude_opus_v4_6` model definition in `AnthropicBedrockModels.swift`
- Implemented `Claude_Opus_v4_6` modality struct in `AnthropicGlobalModels.swift` with support for:
  - Text generation
  - Converse API (streaming and non-streaming)
  - Global cross-region inference
- Updated `BedrockModel.swift` to include the new model in the initialization logic

### Model Specifications

- **Model ID**: `anthropic.claude-opus-4-6-v1`
- **Max tokens**: 128,000 (default: 8,192)
- **Max prompt size**: 200,000 tokens
- **Max reasoning tokens**: 8,191 (default: 4,096)
- **Features**: Text generation, system prompts, document processing, vision, tool use, reasoning

### Technical Details

The implementation follows the existing pattern for Anthropic models, delegating to the `AnthropicText` helper for request/response handling while implementing the required modality protocols for Bedrock and Converse API compatibility.
Revert

