### PR TITLE
Add support for Claude Opus 4.7

### DIFF
--- a/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
@@ -267,4 +267,20 @@ extension BedrockModel {
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
+    public static let claude_opus_v4_7: BedrockModel = BedrockModel(
+        id: "anthropic.claude-opus-4-7",
+        name: "Claude Opus v4.7",
+        modality: Claude_Opus_v4_7(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 128_000, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 0.999),
+                topK: Parameter(.topK, minValue: 0, maxValue: 500, defaultValue: 0),
+                stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
+                maxPromptSize: 1_000_000
+            ),
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning],
+            maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
+        )
+    )
 }

--- a/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
@@ -161,7 +161,6 @@ struct Claude_Opus_v4_6: TextModality, ConverseModality, ConverseStreamingModali
     }
 }
 
-
 struct Claude_Opus_v4_7: TextModality, ConverseModality, ConverseStreamingModality,
     GlobalCrossRegionInferenceModality
 {

--- a/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
@@ -160,3 +160,52 @@ struct Claude_Opus_v4_6: TextModality, ConverseModality, ConverseStreamingModali
         try anthropicText.getTextResponseBody(from: data)
     }
 }
+
+
+struct Claude_Opus_v4_7: TextModality, ConverseModality, ConverseStreamingModality,
+    GlobalCrossRegionInferenceModality
+{
+    private let anthropicText: AnthropicText
+
+    let converseParameters: ConverseParameters
+    let converseFeatures: [ConverseFeature]
+
+    init(parameters: TextGenerationParameters, features: [ConverseFeature], maxReasoningTokens: Parameter<Int>) {
+        self.anthropicText = AnthropicText(
+            parameters: parameters,
+            features: features,
+            maxReasoningTokens: maxReasoningTokens
+        )
+        self.converseParameters = anthropicText.converseParameters
+        self.converseFeatures = anthropicText.converseFeatures
+    }
+
+    func getName() -> String { anthropicText.getName() }
+    func getParameters() -> TextGenerationParameters { anthropicText.getParameters() }
+    func getConverseParameters() -> ConverseParameters { anthropicText.getConverseParameters() }
+    func getConverseFeatures() -> [ConverseFeature] { anthropicText.getConverseFeatures() }
+
+    func getTextRequestBody(
+        prompt: String,
+        maxTokens: Int?,
+        temperature: Double?,
+        topP: Double?,
+        topK: Int?,
+        stopSequences: [String]?,
+        serviceTier: ServiceTier
+    ) throws -> BedrockBodyCodable {
+        try anthropicText.getTextRequestBody(
+            prompt: prompt,
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            stopSequences: stopSequences,
+            serviceTier: serviceTier
+        )
+    }
+
+    func getTextResponseBody(from data: Data) throws -> ContainsTextCompletion {
+        try anthropicText.getTextResponseBody(from: data)
+    }
+}

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -85,6 +85,8 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
             self = BedrockModel.claude_opus_v4_5
         case BedrockModel.claude_opus_v4_6.id:
             self = BedrockModel.claude_opus_v4_6
+        case BedrockModel.claude_opus_v4_7.id:
+            self = BedrockModel.claude_opus_v4_7
         // titan
         case BedrockModel.titan_text_g1_premier.id:
             self = BedrockModel.titan_text_g1_premier


### PR DESCRIPTION
## Summary

Add support for Anthropic's Claude Opus 4.7, their most capable generally available model (launched April 16, 2026).

## Model Details

- **Model ID:** `anthropic.claude-opus-4-7`
- **Context window:** 1M tokens
- **Max output tokens:** 128K
- **Reasoning:** Supported (adaptive only — `thinking.type: "adaptive"`)
- **Knowledge cutoff:** January 2026
- **Features:** text generation, system prompts, document, vision, tool use, reasoning
- **Cross-region inference:** Supported (US, EU, JP, AU, Global)

## Usage

```swift
let response = try await bedrock.converse(
    modelId: .claude_opus_v4_7,
    messages: [.user("Explain quantum computing")]
)
```

## Changes

- Add `Claude_Opus_v4_7` struct in `AnthropicGlobalModels.swift` (supports `GlobalCrossRegionInferenceModality`)
- Add `.claude_opus_v4_7` static model definition in `AnthropicBedrockModels.swift`
- Register model ID in `BedrockModel.swift` init

## Testing

- `swift build` passes
- All 102 tests pass