### PR TITLE
Trigger CI on push to main to seed SPM cache

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,6 +3,8 @@ name: Build, tests & soundness checks
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
PR branches can only restore caches saved from the base branch (main). Adding a `push` trigger on `main` ensures the cache is populated when PRs are merged, so subsequent PRs get cache hits.