### PR TITLE
Add support for Stability AI text-to-image models

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,7 +109,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'api-key', 'converse', 'converse-stream', 'embeddings', 'openai', 'retrieve', 'text_chat' ]"
+      examples: "[ 'api-key', 'converse', 'converse-stream', 'embeddings', 'openai', 'retrieve', 'text_chat', 'stability-image' ]"
 
   swift-6-language-mode:
     name: Swift 6 Language Mode

--- a/.kiro/specs/stability-image-generation/design.md
+++ b/.kiro/specs/stability-image-generation/design.md
@@ -1,0 +1,348 @@
+# Design: Stability AI Text-to-Image Models
+
+## Architecture
+
+The library already has clean extension points for new image-generation providers:
+
+- A model declares its capabilities by conforming its `modality` to one or more protocols in `Sources/BedrockService/BedrockRuntimeClient/Modalities/ImageModality.swift` (`ImageModality`, `TextToImageModality`, `ConditionedTextToImageModality`, `ImageVariationModality`).
+- `BedrockService.generateImage(...)` (in `BedrockService+InvokeModelImage.swift`) is provider-agnostic. It validates parameters via `validateTextToImageParams`, builds the body through `model.getTextToImageModality().getTextToImageRequestBody(...)`, and decodes the response through `model.getImageModality().getImageResponseBody(...)`.
+- The Amazon Nova Canvas implementation lives in `Sources/BedrockService/Models/Amazon/` (`AmazonImage.swift`, `AmazonImageRequestBody.swift`, `AmazonImageResponseBody.swift`, `Nova/NovaBedrockModels.swift`, `Nova/NovaImageResolutionValidator.swift`).
+
+The Stability implementation mirrors the Nova layout in a new `Sources/BedrockService/Models/Stability/` directory. No changes to public-API method signatures are required — Stability slots into the protocol-based dispatch.
+
+## File layout
+
+```
+Sources/BedrockService/Models/Stability/
+├── StabilityImage.swift                  // modality conformance
+├── StabilityImageRequestBody.swift       // BedrockBodyCodable
+├── StabilityImageResponseBody.swift      // ContainsImageGeneration
+├── StabilityImageResolutionValidator.swift
+├── StabilityAspectRatio.swift            // enum + ImageResolution mapping
+└── StabilityBedrockModels.swift          // BedrockModel constants
+```
+
+## Type design
+
+### 1. `StabilityAspectRatio`
+
+```swift
+public enum StabilityAspectRatio: String, Codable, Sendable, CaseIterable {
+    case r16x9 = "16:9"
+    case r1x1  = "1:1"
+    case r21x9 = "21:9"
+    case r2x3  = "2:3"
+    case r3x2  = "3:2"
+    case r4x5  = "4:5"
+    case r5x4  = "5:4"
+    case r9x16 = "9:16"
+    case r9x21 = "9:21"
+
+    /// Returns the nearest supported aspect ratio for an `ImageResolution`.
+    static func nearest(to resolution: ImageResolution) -> StabilityAspectRatio { /* min |w/h - ratio| */ }
+}
+```
+
+### 2. `StabilityImageResolutionValidator`
+
+Implements `ImageResolutionValidator`. Stability does not enforce pixel dimensions on input the way Nova does — instead it picks dimensions from the aspect ratio. Validation:
+
+- Width and height > 0.
+- The computed nearest aspect ratio must exist in `StabilityAspectRatio`.
+- Reject obviously degenerate ratios (e.g. > 21:1) with `BedrockLibraryError.invalidParameter(.resolution, ...)`.
+
+Resolution → aspect ratio mapping happens at request-body construction time (request body holds an `aspect_ratio` string, not width/height).
+
+### 3. `StabilityImageRequestBody`
+
+```swift
+public struct StabilityImageRequestBody: BedrockBodyCodable {
+    let prompt: String
+    let negativePrompt: String?       // omitted for core/ultra
+    let aspectRatio: String?          // "1:1" etc.
+    let seed: Int?
+    let outputFormat: String          // "png" (hard-coded for now)
+    let mode: String?                 // sd3-5-large only
+
+    enum CodingKeys: String, CodingKey {
+        case prompt
+        case negativePrompt   = "negative_prompt"
+        case aspectRatio      = "aspect_ratio"
+        case seed
+        case outputFormat     = "output_format"
+        case mode
+    }
+
+    static func textToImage(
+        prompt: String,
+        negativePrompt: String?,
+        aspectRatio: StabilityAspectRatio?,
+        seed: Int?,
+        supportsNegativePrompt: Bool,
+        supportsMode: Bool
+    ) -> Self { /* ... */ }
+}
+```
+
+`encode(to:)` is implemented manually so unset optionals (notably `negative_prompt` for Core/Ultra and `mode` for non-SD3.5) are omitted from the JSON entirely — Bedrock rejects unknown fields on these models.
+
+### 4. `StabilityImageResponseBody`
+
+```swift
+public struct StabilityImageResponseBody: ContainsImageGeneration {
+    let images: [String]               // base64-encoded
+    let seeds: [Int]?
+    let finishReasons: [String?]?
+
+    enum CodingKeys: String, CodingKey {
+        case images
+        case seeds
+        case finishReasons = "finish_reasons"
+    }
+
+    public func getGeneratedImage() -> ImageGenerationOutput {
+        let datas: [Data] = images.compactMap { Data(base64Encoded: $0) }
+        return ImageGenerationOutput(images: datas)
+    }
+}
+```
+
+### 5. `StabilityImage` (modality)
+
+```swift
+struct StabilityImage: ImageModality, TextToImageModality {
+    let parameters: ImageGenerationParameters
+    let textToImageParameters: TextToImageParameters
+    let resolutionValidator: any ImageResolutionValidator
+    let supportsNegativePrompt: Bool   // false for core/ultra, true for sd3-5-large
+    let supportsMode: Bool             // true for sd3-5-large only
+
+    func getName() -> String { "Stability Image Generation" }
+
+    func getParameters() -> ImageGenerationParameters { parameters }
+    func getTextToImageParameters() -> TextToImageParameters { textToImageParameters }
+
+    func validateResolution(_ resolution: ImageResolution) throws {
+        try resolutionValidator.validateResolution(resolution)
+    }
+
+    func getImageResponseBody(from data: Data) throws -> ContainsImageGeneration {
+        try JSONDecoder().decode(StabilityImageResponseBody.self, from: data)
+    }
+
+    func getTextToImageRequestBody(
+        prompt: String,
+        negativeText: String?,
+        nrOfImages: Int?,
+        cfgScale: Double?,
+        seed: Int?,
+        quality: ImageQuality?,
+        resolution: ImageResolution?
+    ) throws -> BedrockBodyCodable {
+        // Reject unsupported parameters loudly:
+        if let nrOfImages, nrOfImages != 1 {
+            throw BedrockLibraryError.notSupported(
+                "Stability models generate exactly 1 image per request; nrOfImages=\(nrOfImages) is not supported"
+            )
+        }
+        if cfgScale != nil {
+            throw BedrockLibraryError.notSupported("cfgScale is not supported by Stability models")
+        }
+        if quality != nil {
+            throw BedrockLibraryError.notSupported("quality is not supported by Stability models")
+        }
+        if !supportsNegativePrompt, negativeText != nil {
+            throw BedrockLibraryError.notSupported(
+                "negativePrompt is only supported by stability.sd3-5-large-v1:0"
+            )
+        }
+
+        let aspect = resolution.map(StabilityAspectRatio.nearest(to:))
+        return StabilityImageRequestBody.textToImage(
+            prompt: prompt,
+            negativePrompt: negativeText,
+            aspectRatio: aspect,
+            seed: seed,
+            supportsNegativePrompt: supportsNegativePrompt,
+            supportsMode: supportsMode
+        )
+    }
+}
+```
+
+### 6. `BedrockModel` constants — `StabilityBedrockModels.swift`
+
+```swift
+extension BedrockModel {
+    public static let stable_image_core: BedrockModel = BedrockModel(
+        id: "stability.stable-image-core-v1:1",
+        name: "Stable Image Core",
+        modality: StabilityImage(
+            parameters: ImageGenerationParameters(
+                nrOfImages: Parameter(.nrOfImages, minValue: 1, maxValue: 1, defaultValue: 1),
+                cfgScale:   Parameter(.cfgScale,   minValue: 0, maxValue: 0, defaultValue: 0),
+                seed:       Parameter(.seed,       minValue: 0, maxValue: 4_294_967_295, defaultValue: 0)
+            ),
+            textToImageParameters: TextToImageParameters(maxPromptSize: 10_000, maxNegativePromptSize: 0),
+            resolutionValidator: StabilityImageResolutionValidator(),
+            supportsNegativePrompt: false,
+            supportsMode: false
+        )
+    )
+
+    public static let stable_image_ultra: BedrockModel = BedrockModel(
+        id: "stability.stable-image-ultra-v1:1",
+        name: "Stable Image Ultra",
+        modality: StabilityImage(/* same shape as Core */)
+    )
+
+    public static let sd3_5_large: BedrockModel = BedrockModel(
+        id: "stability.sd3-5-large-v1:0",
+        name: "Stable Diffusion 3.5 Large",
+        modality: StabilityImage(
+            parameters: ImageGenerationParameters(
+                nrOfImages: Parameter(.nrOfImages, minValue: 1, maxValue: 1, defaultValue: 1),
+                cfgScale:   Parameter(.cfgScale,   minValue: 0, maxValue: 0, defaultValue: 0),
+                seed:       Parameter(.seed,       minValue: 0, maxValue: 4_294_967_295, defaultValue: 0)
+            ),
+            textToImageParameters: TextToImageParameters(maxPromptSize: 10_000, maxNegativePromptSize: 10_000),
+            resolutionValidator: StabilityImageResolutionValidator(),
+            supportsNegativePrompt: true,
+            supportsMode: true
+        )
+    )
+}
+```
+
+> Note: `cfgScale` is declared with `minValue == maxValue == 0` only as a placeholder so the `ImageGenerationParameters` initializer has a value. The modality's own `getTextToImageRequestBody` rejects any non-nil `cfgScale` *before* the parameter range is checked, so users always get a clear "not supported" message rather than a confusing range error. If preferred, we can add an `Optional<Parameter<Double>>` overload to `ImageGenerationParameters` instead — see the open question below.
+
+## Validation flow
+
+`BedrockService+ImageParameterValidation.swift` already routes through `model.getImageModality().getParameters()` and `model.getTextToImageModality().getTextToImageParameters()`. No changes needed there. Stability-specific rejections live in `StabilityImage.getTextToImageRequestBody(...)` so they fire after generic validation passes.
+
+## Mock & tests
+
+- Add a `case "Stability Image Generation":` branch to `MockBedrockRuntimeClient.invokeModel(...)` that returns a Stability-shaped JSON body with one image and a seed.
+- Add a `Tests/InvokeModel/StabilityImageGenerationTests.swift` mirroring `ImageGenerationTests.swift`. Reuse the parametric pattern with a `StabilityTestConstants` enum (or extend `NovaTestConstants` — favor a new file to keep the Nova file tidy).
+- Add an `imageGenerationModels` array containing the three Stability models for iteration tests; keep the Nova/Titan list separate to avoid cross-pollinating parameter expectations (e.g. `nrOfImages > 1` is valid for Nova but invalid for Stability).
+
+## Test coverage (REQ-14)
+
+The new code must be covered by Swift Testing tests in three new files:
+
+- `Tests/InvokeModel/StabilityImageGenerationTests.swift` — end-to-end behavior through `bedrock.generateImage(...)` for all three models, parametrized via a `StabilityTestConstants` enum mirroring `NovaTestConstants`.
+- `Tests/Stability/StabilityRequestBodyTests.swift` — encodes a `StabilityImageRequestBody`, decodes the JSON back into a dictionary, and asserts which keys are present/absent for each model variant. Covers `negative_prompt` omitted on Core/Ultra, `mode` omitted unless `supportsMode`, and `aspect_ratio` / `seed` omitted when nil.
+- `Tests/Stability/StabilityAspectRatioTests.swift` — table-driven `nearest(to:)` test plus rejection cases on `StabilityImageResolutionValidator`.
+
+The unit tests must also exercise base64 decoding in `StabilityImageResponseBody.getGeneratedImage()` (one valid case, one malformed case). Aim for "every public symbol and every non-trivial branch reached" — measurable by `swift test --enable-code-coverage` if coverage is later wired in. Document any deliberately uncovered path inline with a `// swiftformat:disable` or `// not exercised: <reason>` comment.
+
+## Example project (REQ-15)
+
+Create a new standalone example package mirroring `Examples/embeddings/`:
+
+```
+Examples/stability-image/
+├── Package.swift
+└── Sources/
+    └── StabilityImage/
+        └── StabilityImage.swift
+```
+
+`Package.swift` skeleton (matches the structure of existing examples):
+
+```swift
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "StabilityImage",
+    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18)],
+    products: [
+        .executable(name: "StabilityImage", targets: ["StabilityImage"])
+    ],
+    dependencies: [
+        .package(name: "swift-bedrock-library", path: "../.."),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "StabilityImage",
+            dependencies: [
+                .product(name: "BedrockService", package: "swift-bedrock-library"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        )
+    ]
+)
+```
+
+`StabilityImage.swift` calls `BedrockService.generateImage(...)` against `BedrockModel.stable_image_core` in `us-west-2` and writes the decoded PNG bytes to a file in the working directory.
+
+### CI integration
+
+Append `'stability-image'` to the JSON array in the `integration-tests` job of `.github/workflows/pull_request.yml`:
+
+```yaml
+examples: "[ 'api-key', 'converse', 'converse-stream', 'embeddings', 'openai', 'retrieve', 'text_chat', 'stability-image' ]"
+```
+
+The integration-tests workflow only runs `swift build` against the example, so this does not require AWS credentials.
+
+## DocC documentation (REQ-16)
+
+Add `Sources/BedrockService/Docs.docc/StabilityImageGeneration.md` as a standalone article (preferred over inlining into `ImageGeneration.md` because the differences are substantial enough — different regions, different parameters, different model semantics). Structure:
+
+```
+# Stability AI Image Generation
+@Metadata { @PageImage(purpose: card, source: "stability-card", alt: "...") }   // optional, only if a card asset already exists
+
+## Overview
+- Region availability: us-west-2 only as of 2026-05.
+- Models: stable_image_core, stable_image_ultra, sd3_5_large (text-to-image only in this release).
+
+## Model identifiers
+| Constant | Bedrock ID | Notes |
+| ...      | ...        | ...   |
+
+## Quick start
+\`\`\`swift
+let bedrock = try await BedrockService(region: .uswest2)
+let output = try await bedrock.generateImage(
+    "A serene landscape with mountains at sunset",
+    with: .stable_image_core,
+    seed: 42,
+    resolution: ImageResolution(width: 1920, height: 1080)
+)
+let png = output.images.first!
+try png.write(to: URL(fileURLWithPath: "out.png"))
+\`\`\`
+
+## Parameter mapping
+- `resolution` → nearest supported `aspect_ratio` (16:9, 1:1, 21:9, 2:3, 3:2, 4:5, 5:4, 9:16, 9:21).
+- `nrOfImages` must be `nil` or `1` — Stability returns exactly one image per call.
+- `cfgScale` and `quality` are not supported and will throw `BedrockLibraryError.notSupported`.
+- `negativePrompt` is supported only by `sd3_5_large`.
+
+## See Also
+- <doc:ImageGeneration>
+```
+
+Cross-link from `ImageGeneration.md`: add a `<doc:StabilityImageGeneration>` entry to its **See Also** section so navigation works in both directions.
+
+## Documentation
+
+- `parameter_cheatsheet.md`: new "Stability" subsection with one table per model.
+
+## Open question
+
+`ImageGenerationParameters` currently requires non-optional `cfgScale` and `nrOfImages` parameters. Two options:
+
+1. **Use placeholder zero ranges** (current sketch above) and rely on the modality to reject unsupported params. Pro: zero churn to shared types. Con: the placeholders look odd in the model definitions.
+2. **Make the fields optional** in `ImageGenerationParameters`. Pro: cleaner Stability registration. Con: ripples into `BedrockService+ImageParameterValidation.swift` and `Nova`/`Titan` registrations — wider blast radius.
+
+Recommendation: start with option 1 to keep the change focused. If reviewers prefer cleaner semantics, switch to option 2 in a follow-up.
+
+## Compatibility
+
+- All three models are exclusively in `us-west-2`. Calling them from another region will fail at the SDK layer with the standard "model not found" error; the library does not need region gating.
+- The cross-region inference prefix logic in `BedrockModel.getModelIdWithCrossRegionInferencePrefix(region:)` is opt-in per model and is not enabled for these constants.

--- a/.kiro/specs/stability-image-generation/requirements.md
+++ b/.kiro/specs/stability-image-generation/requirements.md
@@ -1,0 +1,82 @@
+# Requirements: Add Stability AI Text-to-Image Models
+
+## Overview
+
+Add support for Stability AI text-to-image models on Amazon Bedrock to the `BedrockService` library. These are currently the only generic text-to-image models still active on Bedrock and the only practical replacement for Nova Canvas in regions where Canvas has been retired.
+
+## Background
+
+- Stability AI is the sole vendor with active generic text-to-image models on Bedrock.
+- Nova Canvas remains only as a legacy model in `eu-west-1`. Newer regions (notably `us-west-2`) host Stability instead. There is no Amazon first-party replacement yet.
+- Supported model IDs (as of 2026-05-23):
+  - `stability.stable-image-core-v1:1` — text-to-image only (input: TEXT)
+  - `stability.stable-image-ultra-v1:1` — text-to-image only (input: TEXT)
+  - `stability.sd3-5-large-v1:0` — Stable Diffusion 3.5 Large (input: TEXT + IMAGE)
+- All three are available in `us-west-2` only. `us-east-1` / `us-east-2` only host the specialized Stability editing tools (upscale, inpaint, etc.) which are out of scope here.
+- Stability InvokeModel API uses a different request/response schema from Nova Canvas (see "Schema differences" below).
+
+## Schema differences vs Nova Canvas
+
+Stability text-to-image request body fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `prompt` | string | required, ≤ 10000 chars |
+| `negative_prompt` | string | optional, ≤ 10000 chars (not supported by `stable-image-core` or `stable-image-ultra` — only `sd3-5-large`) |
+| `aspect_ratio` | string | optional, one of `16:9`, `1:1`, `21:9`, `2:3`, `3:2`, `4:5`, `5:4`, `9:16`, `9:21`. Default `1:1`. |
+| `seed` | int | optional, 0..4_294_967_295, default 0 (random) |
+| `output_format` | string | optional, `jpeg` or `png`. Default `png`. |
+| `mode` | string | `sd3-5-large` only: `text-to-image` (default) or `image-to-image` |
+
+Stability response body:
+
+```json
+{ "seeds": [123], "finish_reasons": [null], "images": ["<base64-png>"] }
+```
+
+Single image per call (`numberOfImages` is not a Stability parameter); the `images` array always has exactly one element.
+
+## Requirements
+
+1. **REQ-1**: Register three new `BedrockModel` constants in a new `Stability` model directory:
+   - `BedrockModel.stable_image_core`
+   - `BedrockModel.stable_image_ultra`
+   - `BedrockModel.sd3_5_large`
+2. **REQ-2**: Each model must conform to `ImageModality` and `TextToImageModality` so the existing `BedrockService.generateImage(...)` API works without signature changes.
+3. **REQ-3**: SD 3.5 Large must additionally accept a non-nil `negativePrompt`. For Core and Ultra, supplying `negativePrompt` must throw `BedrockLibraryError.notSupported` (or equivalent) — the SDK rejects the field for those models.
+4. **REQ-4**: `nrOfImages` is not a Stability parameter. Accept only `nil` or `1`; any other value must throw `BedrockLibraryError.invalidParameter`.
+5. **REQ-5**: `cfgScale` and `quality` are not Stability parameters. The library must reject any non-nil value for these with a clear "not supported" error to avoid silent ignoring.
+6. **REQ-6**: `resolution` (an `ImageResolution`) must be mapped to the nearest supported `aspect_ratio` string by the model's modality. Mapping logic lives in a `StabilityImageResolutionValidator` (see design). Unsupported aspect ratios must throw `BedrockLibraryError.invalidParameter`.
+7. **REQ-7**: `seed` validation must use Stability's range: `0..4_294_967_295`.
+8. **REQ-8**: Default `output_format` is `png`. Initial scope does not expose `output_format` in the public API; PNG is hard-coded. (Adding it later is a follow-up.)
+9. **REQ-9**: Response decoding must convert each base64 string in `images` to `Data` so the existing `ImageGenerationOutput` (`images: [Data]`) is unchanged.
+10. **REQ-10**: Image-to-image support for `sd3-5-large-v1:0` is **out of scope** for this change and tracked as a follow-up task. The model is registered as text-to-image only here.
+11. **REQ-11**: Add unit tests (Swift Testing) mirroring the patterns in `Tests/InvokeModel/ImageGenerationTests.swift` for all three models, including invalid-parameter cases.
+12. **REQ-12**: Extend `Tests/Mock/MockBedrockRuntimeClient.swift` to handle a `"Stability Image Generation"` modality name and return a Stability-shaped JSON response.
+13. **REQ-13**: Update `parameter_cheatsheet.md` with a new "Stability" section documenting valid ranges and supported aspect ratios per model.
+14. **REQ-14**: **Test coverage** — every new public symbol and every non-trivial branch in the new code must be exercised by tests. This includes:
+    - All three model registrations (parametric tests iterating over `[stable_image_core, stable_image_ultra, sd3_5_large]`).
+    - `StabilityAspectRatio.nearest(to:)` for each of the 9 supported ratios plus midpoint edge cases.
+    - `StabilityImageResolutionValidator` happy path and rejection paths.
+    - `StabilityImageRequestBody` JSON encoding: the conditional omission of `negative_prompt`, `aspect_ratio`, `seed`, and `mode` (assert via decoding the encoded `Data` back into a dictionary).
+    - `StabilityImageResponseBody.getGeneratedImage()` base64-decoding, including a malformed-base64 case.
+    - All "not supported" rejections in `StabilityImage.getTextToImageRequestBody(...)` (`nrOfImages != 1`, non-nil `cfgScale`, non-nil `quality`, non-nil `negativePrompt` for Core/Ultra).
+    - Seed boundary validation at `0` and `4_294_967_295`.
+15. **REQ-15**: **Example project** — add a new standalone example package at `Examples/stability-image/` that calls `BedrockService.generateImage(...)` against `stable_image_core` in `us-west-2` and writes the resulting PNG to disk. The example must:
+    - Follow the structure of existing examples (e.g. `Examples/embeddings/`): own `Package.swift`, `Sources/StabilityImage/`, executable target, `swift-bedrock-library` referenced via local path, `swift-log` as a dependency.
+    - Be compilable with `swift build` from inside its directory without AWS credentials.
+    - Be added to the `examples` matrix in `.github/workflows/pull_request.yml` so CI builds it on every PR.
+16. **REQ-16**: **DocC documentation** — add a new article `Sources/BedrockService/Docs.docc/StabilityImageGeneration.md` (or, if reviewers prefer, a "Stability AI" section appended to the existing `ImageGeneration.md`). Either way the documentation must cover:
+    - Region availability (us-west-2 only).
+    - Each of the three model identifiers with a one-line description.
+    - The resolution → aspect ratio mapping behavior.
+    - The single-image-per-call contract and the rejected parameters (`nrOfImages > 1`, `cfgScale`, `quality`, and `negativePrompt` for Core/Ultra).
+    - A working code snippet using `BedrockModel.stable_image_core`.
+    - A "See Also" link from/to `ImageGeneration.md` so the new article is reachable from the existing IA.
+
+## Non-goals
+
+- The Stability editing endpoints (upscale, inpaint, outpaint, style transfer, sketch, structure, replace-background-and-relight) are out of scope.
+- Image-to-image for `sd3-5-large` is explicitly deferred.
+- Exposing `output_format` selection in the public API is deferred.
+- No changes to the public `generateImage(...)` signature.

--- a/.kiro/specs/stability-image-generation/tasks.md
+++ b/.kiro/specs/stability-image-generation/tasks.md
@@ -1,0 +1,106 @@
+# Tasks: Stability AI Text-to-Image Models
+
+## Task 1: Scaffold the Stability model directory
+- [ ] Create `Sources/BedrockService/Models/Stability/`
+- [ ] Add Apache-2.0 license headers matching existing files
+
+## Task 2: Aspect ratio mapping
+- [ ] Add `StabilityAspectRatio` enum (`StabilityAspectRatio.swift`) with all 9 supported ratios
+- [ ] Implement `static func nearest(to: ImageResolution) -> StabilityAspectRatio` (minimize `|w/h - ratio|`)
+- [ ] Add unit tests covering: square inputs → `1:1`, common landscape/portrait inputs → `16:9` / `9:16`, edge cases at the midpoint between two ratios
+
+## Task 3: Resolution validator
+- [ ] Add `StabilityImageResolutionValidator` conforming to `ImageResolutionValidator`
+- [ ] Validate width/height > 0
+- [ ] Reject ratios outside the supported set with `BedrockLibraryError.invalidParameter(.resolution, ...)`
+
+## Task 4: Request body
+- [ ] Add `StabilityImageRequestBody` conforming to `BedrockBodyCodable`
+- [ ] Provide a `static func textToImage(...)` factory
+- [ ] Implement custom `encode(to:)` so `negative_prompt`, `aspect_ratio`, `seed`, and `mode` are omitted when nil
+- [ ] Hard-code `output_format = "png"` for now (REQ-8)
+
+## Task 5: Response body
+- [ ] Add `StabilityImageResponseBody` conforming to `ContainsImageGeneration`
+- [ ] Decode `images: [String]`, `seeds: [Int]?`, `finish_reasons: [String?]?`
+- [ ] In `getGeneratedImage()`, base64-decode each image to `Data`
+
+## Task 6: Modality conformance
+- [ ] Add `StabilityImage` struct conforming to `ImageModality` and `TextToImageModality`
+- [ ] `getName()` returns `"Stability Image Generation"`
+- [ ] In `getTextToImageRequestBody(...)`, reject `nrOfImages != 1`, non-nil `cfgScale`, non-nil `quality`, and non-nil `negativeText` for Core/Ultra (REQ-3, REQ-4, REQ-5)
+- [ ] Map `resolution` to `StabilityAspectRatio.nearest(to:)` before constructing the body
+
+## Task 7: Register `BedrockModel` constants
+- [ ] Add `StabilityBedrockModels.swift` with `stable_image_core`, `stable_image_ultra`, `sd3_5_large`
+- [ ] Use seed range `0...4_294_967_295` (REQ-7)
+- [ ] Set `maxPromptSize = 10_000` for all; `maxNegativePromptSize = 10_000` only for `sd3_5_large` (REQ-3)
+- [ ] Resolve the `cfgScale`/`nrOfImages` placeholder approach (see "Open question" in design.md) — start with placeholder zero ranges
+
+## Task 8: Mock client
+- [ ] Add a `case "Stability Image Generation":` branch in `Tests/Mock/MockBedrockRuntimeClient.invokeModel(...)`
+- [ ] Return a Stability-shaped JSON: `{ "seeds": [0], "finish_reasons": [null], "images": ["<base64>"] }`
+- [ ] Use the same mock 1×1 PNG base64 already used by `getImageGeneration(...)`
+
+## Task 9: Unit tests — end-to-end (REQ-11, REQ-14)
+- [ ] Create `Tests/InvokeModel/StabilityImageGenerationTests.swift`
+- [ ] Add a `StabilityTestConstants` enum (new file) mirroring `NovaTestConstants` patterns, with a `imageGenerationModels` array containing all three Stability models
+- [ ] Parametric test: valid prompt → 1 image, iterating over all three models
+- [ ] Empty / oversized prompt → throws, iterating over all three models
+- [ ] `nrOfImages` boundary test: `nil` and `1` succeed, every other value throws
+- [ ] Non-nil `cfgScale` → throws (parametric over a small range)
+- [ ] Non-nil `quality` → throws
+- [ ] `negativePrompt` on Core/Ultra → throws; on `sd3_5_large` → succeeds
+- [ ] Seed boundaries: `0` and `4_294_967_295` succeed; `-1` and `4_294_967_296` throw
+
+## Task 10: Unit tests — request body & response (REQ-14)
+- [ ] Create `Tests/Stability/StabilityRequestBodyTests.swift`
+- [ ] Encode the body, decode back into `[String: Any]`, and assert key presence/absence per model variant:
+  - Core/Ultra: no `negative_prompt`, no `mode` keys
+  - `sd3_5_large` with negativeText: `negative_prompt` present, `mode` present
+  - `aspect_ratio` and `seed` omitted when nil
+- [ ] Verify `output_format` is always `"png"` in the encoded JSON
+- [ ] Create `Tests/Stability/StabilityResponseBodyTests.swift` covering `getGeneratedImage()` with valid base64 (round-trip equality) and malformed base64 (decoded count == 0)
+
+## Task 11: Unit tests — aspect ratio & resolution (REQ-14)
+- [ ] Create `Tests/Stability/StabilityAspectRatioTests.swift`
+- [ ] Table-driven `nearest(to:)` test: at least one input per supported ratio, plus midpoint cases between adjacent ratios
+- [ ] Resolution mapping smoke tests: `(1024,1024) → 1:1`, `(1920,1080) → 16:9`, `(1080,1920) → 9:16`, `(2100,900) → 21:9`
+- [ ] `StabilityImageResolutionValidator` rejection cases: `width=0`, `height=0`, ratio outside the supported set
+
+## Task 12: Mock client wiring
+- [ ] Add a `case "Stability Image Generation":` branch in `Tests/Mock/MockBedrockRuntimeClient.invokeModel(...)`
+- [ ] Return `{ "seeds": [0], "finish_reasons": [null], "images": ["<base64>"] }` using the same 1×1 PNG mock as the Nova path
+  > (This was Task 8 in the previous numbering — kept here for sequencing.)
+
+## Task 13: DocC article (REQ-16)
+- [ ] Add `Sources/BedrockService/Docs.docc/StabilityImageGeneration.md` covering: region availability, model identifiers, parameter mapping (resolution → aspect ratio, single-image contract, rejected params), a working `generateImage` snippet using `stable_image_core`
+- [ ] Add a `<doc:StabilityImageGeneration>` entry to the **See Also** section of `ImageGeneration.md`
+- [ ] Build the docs locally (e.g. `swift package generate-documentation --target BedrockService`) and confirm the new article appears and links resolve
+
+## Task 14: Cheatsheet
+- [ ] Add a "Stability" section to `parameter_cheatsheet.md` with one table per model
+
+## Task 15: Example project (REQ-15)
+- [ ] Create `Examples/stability-image/Package.swift` mirroring `Examples/embeddings/Package.swift` (executable target, local path dep on `swift-bedrock-library`, `swift-log` dep)
+- [ ] Create `Examples/stability-image/Sources/StabilityImage/StabilityImage.swift` calling `bedrock.generateImage(...)` with `.stable_image_core` and writing the PNG to disk
+- [ ] Verify `swift build` succeeds inside `Examples/stability-image/` (no AWS credentials needed for build)
+
+## Task 16: CI integration (REQ-15)
+- [ ] In `.github/workflows/pull_request.yml`, append `'stability-image'` to the `examples` JSON array in the `integration-tests` job
+- [ ] Push a draft PR (or run the workflow via `workflow_dispatch`) and confirm the new example gets built
+
+## Task 17: Build, format, test
+- [ ] `swift build` clean
+- [ ] `swift test` clean (existing tests must not regress)
+- [ ] `swift format` per repository steering rules
+- [ ] If a coverage tool is available locally, run `swift test --enable-code-coverage` and confirm the new files exceed a reasonable threshold (target ≥ 90 % of lines / branches in the new Stability sources)
+
+## Task 18: Manual verification (optional, requires AWS credentials)
+- [ ] Run the new example in `us-west-2` and verify a PNG is decoded into `Data`
+- [ ] Confirm error paths surface readable messages (`negativePrompt` on Core, `nrOfImages: 3`, `cfgScale: 5`)
+
+## Follow-ups (not in this change)
+- [ ] Image-to-image for `sd3-5-large-v1:0` (mode = `image-to-image`, requires a reference image and `strength`) — likely needs a new modality protocol since the semantics differ from `ImageVariationModality`
+- [ ] Public API for selecting `output_format` (jpeg vs png)
+- [ ] The Stability editing tools (upscale, inpaint, outpaint, style transfer) in `us-east-1`/`us-east-2`

--- a/.kiro/steering/claude.md
+++ b/.kiro/steering/claude.md
@@ -1,0 +1,8 @@
+## Pre-commit formatting
+
+Always run `swift format` on any modified Swift files before committing. This ensures consistent code style across the project.
+
+When preparing a commit:
+1. Identify all `.swift` files that have been modified.
+2. Run `swift format -i <file>` on each modified file.
+3. Then stage and commit the changes.

--- a/.kiro/steering/swift.md
+++ b/.kiro/steering/swift.md
@@ -105,3 +105,12 @@ user a code snippet, with normal markdown:
 ```
 
 
+
+## Pre-commit formatting
+
+Always run `swift format` on any modified Swift files before committing. This ensures consistent code style across the project.
+
+When preparing a commit:
+1. Identify all `.swift` files that have been modified.
+2. Run `swift format -i <file>` on each modified file.
+3. Then stage and commit the changes.

--- a/Examples/stability-image/Package.swift
+++ b/Examples/stability-image/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "StabilityImage",
+    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18)],
+    products: [
+        .executable(name: "StabilityImage", targets: ["StabilityImage"])
+    ],
+    dependencies: [
+        // for production use, uncomment the following line
+        // .package(url: "https://github.com/build-on-aws/swift-bedrock-library.git", branch: "main"),
+
+        // for local development, use the following line
+        .package(name: "swift-bedrock-library", path: "../.."),
+
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "StabilityImage",
+            dependencies: [
+                .product(name: "BedrockService", package: "swift-bedrock-library"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        )
+    ]
+)

--- a/Examples/stability-image/Sources/StabilityImage.swift
+++ b/Examples/stability-image/Sources/StabilityImage.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BedrockService
+import Foundation
+
+/// # Stability AI Image Generation Example
+///
+/// Generates a single PNG image with Stable Image Core in `us-west-2` and writes
+/// it to `out.png` in the current working directory.
+///
+/// Stability models on Bedrock differ from Nova Canvas:
+/// - exactly one image per call
+/// - no `cfgScale`, `quality`, or `negativePrompt` (except `sd3-5-large`)
+/// - `resolution` is mapped internally to the closest supported aspect ratio
+@main
+struct StabilityImageExample {
+
+    static func main() async throws {
+        let bedrock = try await BedrockService(region: .uswest2)
+
+        let prompt = "A serene landscape with mountains at sunset, photorealistic"
+        print("Generating image for prompt: \(prompt)")
+
+        let output = try await bedrock.generateImage(
+            prompt,
+            with: .stable_image_core,
+            seed: 42,
+            resolution: ImageResolution(width: 1920, height: 1080)
+        )
+
+        guard let png = output.images.first else {
+            print("No image returned by the model")
+            return
+        }
+
+        let url = URL(fileURLWithPath: "out.png")
+        try png.write(to: url)
+        print("Wrote \(png.count) bytes to \(url.path)")
+    }
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/InvokeModel/ImageResolution.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/InvokeModel/ImageResolution.swift
@@ -22,4 +22,9 @@ import Foundation
 public struct ImageResolution: Codable, Equatable, Sendable {
     public let width: Int
     public let height: Int
+
+    public init(width: Int, height: Int) {
+        self.width = width
+        self.height = height
+    }
 }

--- a/Sources/BedrockService/Docs.docc/ImageGeneration.md
+++ b/Sources/BedrockService/Docs.docc/ImageGeneration.md
@@ -186,5 +186,6 @@ do {
 
 ## See Also
 
+- <doc:StabilityImageGeneration>
 - <doc:Vision>
 - <doc:Converse>

--- a/Sources/BedrockService/Docs.docc/StabilityImageGeneration.md
+++ b/Sources/BedrockService/Docs.docc/StabilityImageGeneration.md
@@ -1,0 +1,68 @@
+# Stability AI Image Generation
+
+Generate images with Stability AI models on Amazon Bedrock.
+
+## Overview
+
+Stability AI provides the only generic text-to-image models currently active on Amazon Bedrock. They are available in **us-west-2** only.
+
+| Constant | Bedrock model ID | Notes |
+| -------- | ---------------- | ----- |
+| ``BedrockModel/stable_image_core`` | `stability.stable-image-core-v1:1` | Text-to-image only. |
+| ``BedrockModel/stable_image_ultra`` | `stability.stable-image-ultra-v1:1` | Text-to-image only. |
+| ``BedrockModel/sd3_5_large`` | `stability.sd3-5-large-v1:0` | Text-to-image; supports `negativePrompt`. Image-to-image is registered as a follow-up. |
+
+## Quick start
+
+```swift
+import BedrockService
+
+let bedrock = try await BedrockService(region: .uswest2)
+
+let output = try await bedrock.generateImage(
+    "A serene landscape with mountains at sunset",
+    with: .stable_image_core,
+    seed: 42,
+    resolution: ImageResolution(width: 1920, height: 1080)
+)
+
+if let png = output.images.first {
+    try png.write(to: URL(fileURLWithPath: "out.png"))
+}
+```
+
+## Parameter mapping
+
+The shared `generateImage` API surface is unchanged for Stability models, but several parameters behave differently than for Nova Canvas:
+
+- **`resolution`** is mapped to the closest supported `aspect_ratio` string. Supported ratios are `16:9`, `1:1`, `21:9`, `2:3`, `3:2`, `4:5`, `5:4`, `9:16`, `9:21`. Resolutions more extreme than `21:9` (or `9:21`) are rejected with `BedrockLibraryError.invalidParameter`.
+- **`nrOfImages`** must be `nil` or `1` — Stability models always return exactly one image per call. Any other value throws `BedrockLibraryError.notSupported`.
+- **`cfgScale`** is not supported by Stability models. Any non-`nil` value throws `BedrockLibraryError.notSupported`.
+- **`quality`** is not supported by Stability models. Any non-`nil` value throws `BedrockLibraryError.notSupported`.
+- **`negativePrompt`** is supported only by ``BedrockModel/sd3_5_large`` (max 10 000 characters). Passing a non-`nil` value to ``BedrockModel/stable_image_core`` or ``BedrockModel/stable_image_ultra`` throws `BedrockLibraryError.notSupported`.
+- **`seed`** must be in the range `0...4_294_967_295`.
+
+The output format is currently fixed to PNG.
+
+## Error handling
+
+```swift
+do {
+    let output = try await bedrock.generateImage(
+        "A futuristic city skyline at night",
+        with: .stable_image_core,
+        nrOfImages: 3
+    )
+} catch BedrockLibraryError.notSupported(let message) {
+    print("Stability rejected the request: \(message)")
+} catch BedrockLibraryError.invalidParameter(let parameter, let message) {
+    print("Invalid parameter \(parameter): \(message)")
+} catch {
+    print("Image generation failed: \(error)")
+}
+```
+
+## See Also
+
+- <doc:ImageGeneration>
+- <doc:Vision>

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -131,6 +131,10 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
         // OpenAI
         case BedrockModel.openai_gpt_oss_20b.id: self = BedrockModel.openai_gpt_oss_20b
         case BedrockModel.openai_gpt_oss_120b.id: self = BedrockModel.openai_gpt_oss_120b
+        // stability
+        case BedrockModel.stable_image_core.id: self = BedrockModel.stable_image_core
+        case BedrockModel.stable_image_ultra.id: self = BedrockModel.stable_image_ultra
+        case BedrockModel.sd3_5_large.id: self = BedrockModel.sd3_5_large
         default:
             return nil
         }

--- a/Sources/BedrockService/Models/Stability/StabilityAspectRatio.swift
+++ b/Sources/BedrockService/Models/Stability/StabilityAspectRatio.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// The aspect ratios supported by Stability AI image generation models on Amazon Bedrock.
+///
+/// Stability models do not accept explicit width/height — they accept an `aspect_ratio`
+/// string. The library maps an `ImageResolution` to the closest supported ratio.
+public enum StabilityAspectRatio: String, Codable, Sendable, CaseIterable {
+    case r16x9 = "16:9"
+    case r1x1 = "1:1"
+    case r21x9 = "21:9"
+    case r2x3 = "2:3"
+    case r3x2 = "3:2"
+    case r4x5 = "4:5"
+    case r5x4 = "5:4"
+    case r9x16 = "9:16"
+    case r9x21 = "9:21"
+
+    /// The numeric ratio (width / height) for this aspect ratio.
+    var ratio: Double {
+        switch self {
+        case .r16x9: return 16.0 / 9.0
+        case .r1x1: return 1.0
+        case .r21x9: return 21.0 / 9.0
+        case .r2x3: return 2.0 / 3.0
+        case .r3x2: return 3.0 / 2.0
+        case .r4x5: return 4.0 / 5.0
+        case .r5x4: return 5.0 / 4.0
+        case .r9x16: return 9.0 / 16.0
+        case .r9x21: return 9.0 / 21.0
+        }
+    }
+
+    /// Returns the supported aspect ratio whose numeric ratio is closest to the
+    /// given resolution.
+    ///
+    /// - Parameter resolution: The desired image resolution.
+    /// - Returns: The closest supported `StabilityAspectRatio`.
+    public static func nearest(to resolution: ImageResolution) -> StabilityAspectRatio {
+        let target = Double(resolution.width) / Double(resolution.height)
+        var best: StabilityAspectRatio = .r1x1
+        var bestDistance = Double.greatestFiniteMagnitude
+        for candidate in StabilityAspectRatio.allCases {
+            let distance = abs(candidate.ratio - target)
+            if distance < bestDistance {
+                bestDistance = distance
+                best = candidate
+            }
+        }
+        return best
+    }
+}

--- a/Sources/BedrockService/Models/Stability/StabilityBedrockModels.swift
+++ b/Sources/BedrockService/Models/Stability/StabilityBedrockModels.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// MARK: image generation
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html
+
+extension BedrockModel {
+
+    /// Stability AI Stable Image Core (text-to-image only).
+    ///
+    /// Available in `us-west-2`. Returns exactly one image per call. Does not
+    /// support `negativePrompt`, `cfgScale`, `quality`, or `nrOfImages > 1`.
+    public static let stable_image_core: BedrockModel = BedrockModel(
+        id: "stability.stable-image-core-v1:1",
+        name: "Stable Image Core",
+        modality: StabilityImage(
+            parameters: ImageGenerationParameters(
+                nrOfImages: Parameter(.nrOfImages, minValue: 1, maxValue: 1, defaultValue: 1),
+                cfgScale: .notSupported(.cfgScale),
+                seed: Parameter(.seed, minValue: 0, maxValue: 4_294_967_295, defaultValue: 0)
+            ),
+            textToImageParameters: TextToImageParameters(maxPromptSize: 10_000, maxNegativePromptSize: 10_000),
+            resolutionValidator: StabilityImageResolutionValidator(),
+            supportsNegativePrompt: false,
+            supportsMode: false
+        )
+    )
+
+    /// Stability AI Stable Image Ultra (text-to-image only).
+    ///
+    /// Available in `us-west-2`. Returns exactly one image per call. Does not
+    /// support `negativePrompt`, `cfgScale`, `quality`, or `nrOfImages > 1`.
+    public static let stable_image_ultra: BedrockModel = BedrockModel(
+        id: "stability.stable-image-ultra-v1:1",
+        name: "Stable Image Ultra",
+        modality: StabilityImage(
+            parameters: ImageGenerationParameters(
+                nrOfImages: Parameter(.nrOfImages, minValue: 1, maxValue: 1, defaultValue: 1),
+                cfgScale: .notSupported(.cfgScale),
+                seed: Parameter(.seed, minValue: 0, maxValue: 4_294_967_295, defaultValue: 0)
+            ),
+            textToImageParameters: TextToImageParameters(maxPromptSize: 10_000, maxNegativePromptSize: 10_000),
+            resolutionValidator: StabilityImageResolutionValidator(),
+            supportsNegativePrompt: false,
+            supportsMode: false
+        )
+    )
+
+    /// Stable Diffusion 3.5 Large (text-to-image; image-to-image registered as a follow-up).
+    ///
+    /// Available in `us-west-2`. Returns exactly one image per call. Supports
+    /// `negativePrompt` (≤ 10 000 chars). Does not support `cfgScale`,
+    /// `quality`, or `nrOfImages > 1`.
+    public static let sd3_5_large: BedrockModel = BedrockModel(
+        id: "stability.sd3-5-large-v1:0",
+        name: "Stable Diffusion 3.5 Large",
+        modality: StabilityImage(
+            parameters: ImageGenerationParameters(
+                nrOfImages: Parameter(.nrOfImages, minValue: 1, maxValue: 1, defaultValue: 1),
+                cfgScale: .notSupported(.cfgScale),
+                seed: Parameter(.seed, minValue: 0, maxValue: 4_294_967_295, defaultValue: 0)
+            ),
+            textToImageParameters: TextToImageParameters(maxPromptSize: 10_000, maxNegativePromptSize: 10_000),
+            resolutionValidator: StabilityImageResolutionValidator(),
+            supportsNegativePrompt: true,
+            supportsMode: true
+        )
+    )
+}

--- a/Sources/BedrockService/Models/Stability/StabilityImage.swift
+++ b/Sources/BedrockService/Models/Stability/StabilityImage.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Modality conformance for Stability AI text-to-image models on Amazon Bedrock.
+///
+/// Stability models on Bedrock differ from Nova Canvas in several ways:
+/// - they accept an `aspect_ratio` string instead of explicit width/height
+/// - they always return exactly one image per request (no `numberOfImages`)
+/// - they do not accept a `cfgScale` or a `quality` field
+/// - only `sd3-5-large` accepts a `negative_prompt`
+///
+/// The shared `BedrockService.generateImage(...)` API surface remains unchanged.
+/// Unsupported parameters are rejected with `BedrockLibraryError.notSupported`
+/// so callers always get a clear error rather than a silent ignore.
+struct StabilityImage: ImageModality, TextToImageModality {
+
+    let parameters: ImageGenerationParameters
+    let textToImageParameters: TextToImageParameters
+    let resolutionValidator: any ImageResolutionValidator
+    let supportsNegativePrompt: Bool
+    let supportsMode: Bool
+
+    init(
+        parameters: ImageGenerationParameters,
+        textToImageParameters: TextToImageParameters,
+        resolutionValidator: any ImageResolutionValidator,
+        supportsNegativePrompt: Bool,
+        supportsMode: Bool
+    ) {
+        self.parameters = parameters
+        self.textToImageParameters = textToImageParameters
+        self.resolutionValidator = resolutionValidator
+        self.supportsNegativePrompt = supportsNegativePrompt
+        self.supportsMode = supportsMode
+    }
+
+    func getName() -> String { "Stability Image Generation" }
+
+    func getParameters() -> ImageGenerationParameters { parameters }
+    func getTextToImageParameters() -> TextToImageParameters { textToImageParameters }
+
+    func validateResolution(_ resolution: ImageResolution) throws {
+        try resolutionValidator.validateResolution(resolution)
+    }
+
+    func getImageResponseBody(from data: Data) throws -> ContainsImageGeneration {
+        try JSONDecoder().decode(StabilityImageResponseBody.self, from: data)
+    }
+
+    func getTextToImageRequestBody(
+        prompt: String,
+        negativeText: String?,
+        nrOfImages: Int?,
+        cfgScale: Double?,
+        seed: Int?,
+        quality: ImageQuality?,
+        resolution: ImageResolution?
+    ) throws -> BedrockBodyCodable {
+
+        if let nrOfImages, nrOfImages != 1 {
+            throw BedrockLibraryError.notSupported(
+                "Stability models generate exactly 1 image per request; nrOfImages=\(nrOfImages) is not supported"
+            )
+        }
+        if cfgScale != nil {
+            throw BedrockLibraryError.notSupported("cfgScale is not supported by Stability models")
+        }
+        if quality != nil {
+            throw BedrockLibraryError.notSupported("quality is not supported by Stability models")
+        }
+        if !supportsNegativePrompt, negativeText != nil {
+            throw BedrockLibraryError.notSupported(
+                "negativePrompt is only supported by stability.sd3-5-large-v1:0"
+            )
+        }
+
+        let aspect = resolution.map(StabilityAspectRatio.nearest(to:))
+        let mode: String? = supportsMode ? "text-to-image" : nil
+
+        return StabilityImageRequestBody.textToImage(
+            prompt: prompt,
+            negativePrompt: supportsNegativePrompt ? negativeText : nil,
+            aspectRatio: aspect,
+            seed: seed,
+            mode: mode
+        )
+    }
+}

--- a/Sources/BedrockService/Models/Stability/StabilityImageRequestBody.swift
+++ b/Sources/BedrockService/Models/Stability/StabilityImageRequestBody.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Request body for Stability AI text-to-image models on Amazon Bedrock.
+///
+/// The Stability InvokeModel schema accepts a flat JSON object with a required
+/// `prompt`. Optional fields (`negative_prompt`, `aspect_ratio`, `seed`, `mode`)
+/// are omitted from the encoded JSON when they are not set or not supported by
+/// the target model — Bedrock rejects unknown or unsupported keys for
+/// `stable-image-core` and `stable-image-ultra`.
+public struct StabilityImageRequestBody: BedrockBodyCodable {
+    let prompt: String
+    let negativePrompt: String?
+    let aspectRatio: String?
+    let seed: Int?
+    let outputFormat: String
+    let mode: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case prompt
+        case negativePrompt = "negative_prompt"
+        case aspectRatio = "aspect_ratio"
+        case seed
+        case outputFormat = "output_format"
+        case mode
+    }
+
+    /// Creates a text-to-image request body for a Stability model.
+    ///
+    /// - Parameters:
+    ///   - prompt: The text description of the image to generate.
+    ///   - negativePrompt: Text describing what to avoid. Pass `nil` for models that do not
+    ///     support this field (`stable-image-core`, `stable-image-ultra`).
+    ///   - aspectRatio: The closest supported aspect ratio for the desired resolution.
+    ///   - seed: A seed for reproducible generation in the range `0...4_294_967_295`.
+    ///   - mode: Generation mode for `sd3-5-large` (`text-to-image` / `image-to-image`).
+    ///     Pass `nil` for models that do not support this field.
+    public static func textToImage(
+        prompt: String,
+        negativePrompt: String?,
+        aspectRatio: StabilityAspectRatio?,
+        seed: Int?,
+        mode: String?
+    ) -> Self {
+        StabilityImageRequestBody(
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            aspectRatio: aspectRatio?.rawValue,
+            seed: seed,
+            outputFormat: "png",
+            mode: mode
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(prompt, forKey: .prompt)
+        try container.encode(outputFormat, forKey: .outputFormat)
+        if let negativePrompt {
+            try container.encode(negativePrompt, forKey: .negativePrompt)
+        }
+        if let aspectRatio {
+            try container.encode(aspectRatio, forKey: .aspectRatio)
+        }
+        if let seed {
+            try container.encode(seed, forKey: .seed)
+        }
+        if let mode {
+            try container.encode(mode, forKey: .mode)
+        }
+    }
+}

--- a/Sources/BedrockService/Models/Stability/StabilityImageResolutionValidator.swift
+++ b/Sources/BedrockService/Models/Stability/StabilityImageResolutionValidator.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Validates resolutions for Stability AI image generation models.
+///
+/// Stability models do not enforce explicit pixel dimensions on input — the model
+/// picks dimensions from a closest-matching `aspect_ratio` string. This validator
+/// rejects only obviously invalid inputs (zero or negative dimensions, or
+/// degenerate aspect ratios outside the supported set).
+struct StabilityImageResolutionValidator: ImageResolutionValidator {
+
+    func validateResolution(_ resolution: ImageResolution) throws {
+        let width = resolution.width
+        let height = resolution.height
+
+        guard width > 0 else {
+            throw BedrockLibraryError.invalidParameter(
+                .resolution,
+                "Width must be a positive integer. Width: \(width)"
+            )
+        }
+        guard height > 0 else {
+            throw BedrockLibraryError.invalidParameter(
+                .resolution,
+                "Height must be a positive integer. Height: \(height)"
+            )
+        }
+
+        // Stability supports up to 21:9 in landscape and 9:21 in portrait.
+        // Reject ratios more extreme than that — they cannot be approximated faithfully.
+        let ratio = Double(width) / Double(height)
+        let maxRatio = 21.0 / 9.0
+        let minRatio = 9.0 / 21.0
+        guard ratio <= maxRatio && ratio >= minRatio else {
+            throw BedrockLibraryError.invalidParameter(
+                .resolution,
+                "Aspect ratio must be between 9:21 and 21:9. Width: \(width), Height: \(height)"
+            )
+        }
+    }
+}

--- a/Sources/BedrockService/Models/Stability/StabilityImageResponseBody.swift
+++ b/Sources/BedrockService/Models/Stability/StabilityImageResponseBody.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Response body for Stability AI text-to-image models on Amazon Bedrock.
+///
+/// Stability returns exactly one image per call as a base64-encoded string.
+/// The library decodes those strings into `Data` so the public
+/// `ImageGenerationOutput` shape matches other providers.
+public struct StabilityImageResponseBody: ContainsImageGeneration {
+    let images: [String]
+    let seeds: [Int]?
+    let finishReasons: [String?]?
+
+    private enum CodingKeys: String, CodingKey {
+        case images
+        case seeds
+        case finishReasons = "finish_reasons"
+    }
+
+    public func getGeneratedImage() -> ImageGenerationOutput {
+        let datas: [Data] = images.compactMap { Data(base64Encoded: $0) }
+        return ImageGenerationOutput(images: datas)
+    }
+}

--- a/Tests/InvokeModel/StabilityImageGenerationTests.swift
+++ b/Tests/InvokeModel/StabilityImageGenerationTests.swift
@@ -1,0 +1,219 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import BedrockService
+
+extension BedrockServiceTests {
+
+    // MARK: model dispatch
+
+    @Test(
+        "Generate image using a Stability model",
+        arguments: StabilityTestConstants.imageGenerationModels
+    )
+    func generateImageWithStabilityModel(model: BedrockModel) async throws {
+        let output: ImageGenerationOutput = try await bedrock.generateImage(
+            "A serene landscape with mountains at sunset",
+            with: model
+        )
+        #expect(output.images.count == 1)
+        #expect(output.images.first?.isEmpty == false)
+    }
+
+    // MARK: prompt validation
+
+    @Test(
+        "Stability: valid prompts succeed",
+        arguments: StabilityTestConstants.ImageGeneration.validImagePrompts
+    )
+    func generateImageWithValidPromptStability(prompt: String) async throws {
+        let output: ImageGenerationOutput = try await bedrock.generateImage(
+            prompt,
+            with: BedrockModel.stable_image_core
+        )
+        #expect(output.images.count == 1)
+    }
+
+    @Test(
+        "Stability: invalid prompts throw",
+        arguments: StabilityTestConstants.ImageGeneration.invalidImagePrompts
+    )
+    func generateImageWithInvalidPromptStability(prompt: String) async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _: ImageGenerationOutput = try await bedrock.generateImage(
+                prompt,
+                with: BedrockModel.stable_image_core
+            )
+        }
+    }
+
+    // MARK: nrOfImages
+
+    @Test("Stability: nrOfImages = 1 succeeds")
+    func generateImageWithNrOfImagesOne() async throws {
+        let output = try await bedrock.generateImage(
+            "test",
+            with: BedrockModel.stable_image_core,
+            nrOfImages: 1
+        )
+        #expect(output.images.count == 1)
+    }
+
+    @Test(
+        "Stability: nrOfImages != 1 throws",
+        arguments: StabilityTestConstants.ImageGeneration.invalidNrOfImages
+    )
+    func generateImageWithInvalidNrOfImagesStability(nrOfImages: Int) async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _ = try await bedrock.generateImage(
+                "test",
+                with: BedrockModel.stable_image_core,
+                nrOfImages: nrOfImages
+            )
+        }
+    }
+
+    // MARK: cfgScale (unsupported)
+
+    @Test(
+        "Stability: any cfgScale throws notSupported",
+        arguments: StabilityTestConstants.ImageGeneration.invalidCfgScale
+    )
+    func generateImageWithCfgScaleStability(cfgScale: Double) async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _ = try await bedrock.generateImage(
+                "test",
+                with: BedrockModel.stable_image_core,
+                cfgScale: cfgScale
+            )
+        }
+    }
+
+    // MARK: quality (unsupported)
+
+    @Test("Stability: quality throws notSupported")
+    func generateImageWithQualityStability() async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _ = try await bedrock.generateImage(
+                "test",
+                with: BedrockModel.stable_image_core,
+                quality: .standard
+            )
+        }
+    }
+
+    // MARK: negativePrompt rules
+
+    @Test(
+        "Stability Core/Ultra: negativePrompt throws notSupported",
+        arguments: StabilityTestConstants.modelsRejectingNegativePrompt
+    )
+    func generateImageWithNegativePromptOnUnsupportedModel(model: BedrockModel) async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _ = try await bedrock.generateImage(
+                "test",
+                with: model,
+                negativePrompt: "blurry"
+            )
+        }
+    }
+
+    @Test("SD 3.5 Large: negativePrompt is accepted")
+    func generateImageWithNegativePromptOnSD35() async throws {
+        let output = try await bedrock.generateImage(
+            "test",
+            with: StabilityTestConstants.modelAcceptingNegativePrompt,
+            negativePrompt: "blurry, low quality"
+        )
+        #expect(output.images.count == 1)
+    }
+
+    // MARK: seed
+
+    @Test(
+        "Stability: valid seed values succeed",
+        arguments: StabilityTestConstants.ImageGeneration.validSeed
+    )
+    func generateImageWithValidSeedStability(seed: Int) async throws {
+        let output = try await bedrock.generateImage(
+            "test",
+            with: BedrockModel.stable_image_core,
+            seed: seed
+        )
+        #expect(output.images.count == 1)
+    }
+
+    @Test(
+        "Stability: out-of-range seed throws",
+        arguments: StabilityTestConstants.ImageGeneration.invalidSeed
+    )
+    func generateImageWithInvalidSeedStability(seed: Int) async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _ = try await bedrock.generateImage(
+                "test",
+                with: BedrockModel.stable_image_core,
+                seed: seed
+            )
+        }
+    }
+
+    // MARK: resolution
+
+    @Test("Stability: 1024x1024 succeeds and is mapped to 1:1")
+    func generateImageWithSquareResolution() async throws {
+        let output = try await bedrock.generateImage(
+            "test",
+            with: BedrockModel.stable_image_core,
+            resolution: ImageResolution(width: 1024, height: 1024)
+        )
+        #expect(output.images.count == 1)
+    }
+
+    @Test("Stability: invalid resolution throws")
+    func generateImageWithInvalidResolution() async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _ = try await bedrock.generateImage(
+                "test",
+                with: BedrockModel.stable_image_core,
+                resolution: ImageResolution(width: 0, height: 1024)
+            )
+        }
+    }
+
+    // MARK: invalid model dispatch
+
+    @Test("generateImage on a text model throws invalidModality")
+    func generateImageWithTextModelStability() async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _ = try await bedrock.generateImage(
+                "test",
+                with: BedrockModel.nova_micro
+            )
+        }
+    }
+
+    // MARK: rawValue init coverage
+
+    @Test(
+        "BedrockModel(rawValue:) recognizes Stability IDs",
+        arguments: StabilityTestConstants.imageGenerationModels
+    )
+    func bedrockModelInitFromRawValueStability(model: BedrockModel) async throws {
+        let resolved = BedrockModel(rawValue: model.id)
+        #expect(resolved?.id == model.id)
+    }
+}

--- a/Tests/Mock/MockBedrockRuntimeClient.swift
+++ b/Tests/Mock/MockBedrockRuntimeClient.swift
@@ -186,6 +186,8 @@ public struct MockBedrockRuntimeClient: BedrockRuntimeClientProtocol {
         switch model?.modality.getName() {
         case "Amazon Image Generation":
             return InvokeModelOutput(body: try getImageGeneration(body: inputBody))
+        case "Stability Image Generation":
+            return InvokeModelOutput(body: try getStabilityImageGeneration(body: inputBody))
         case "Nova Text Generation":
             return InvokeModelOutput(body: try invokeNovaModel(body: inputBody))
         case "Titan Text Generation":
@@ -221,6 +223,26 @@ public struct MockBedrockRuntimeClient: BedrockRuntimeClientProtocol {
                 "images": [
                     \(imageArray.joined(separator: ",\n                "))
                 ]
+            }
+            """.data(using: .utf8)!
+    }
+
+    private func getStabilityImageGeneration(body: Data) throws -> Data {
+        guard
+            let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String: Any],
+            json["prompt"] as? String != nil
+        else {
+            throw AWSBedrockRuntime.ValidationException(
+                message: "Malformed input request, please reformat your input and try again."
+            )
+        }
+        let mockBase64Image =
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        return """
+            {
+                "seeds": [0],
+                "finish_reasons": [null],
+                "images": ["\(mockBase64Image)"]
             }
             """.data(using: .utf8)!
     }

--- a/Tests/Stability/StabilityAspectRatioTests.swift
+++ b/Tests/Stability/StabilityAspectRatioTests.swift
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import BedrockService
+
+@Suite("StabilityAspectRatio nearest mapping")
+struct StabilityAspectRatioTests {
+
+    @Test("Square inputs map to 1:1")
+    func squareMapsTo1x1() {
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 1024, height: 1024)) == .r1x1)
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 512, height: 512)) == .r1x1)
+    }
+
+    @Test("Common landscape resolutions map to 16:9")
+    func landscapeMapsTo16x9() {
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 1920, height: 1080)) == .r16x9)
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 1280, height: 720)) == .r16x9)
+    }
+
+    @Test("Common portrait resolutions map to 9:16")
+    func portraitMapsTo9x16() {
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 1080, height: 1920)) == .r9x16)
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 720, height: 1280)) == .r9x16)
+    }
+
+    @Test("Cinematic landscape maps to 21:9")
+    func cinematicLandscape() {
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 2520, height: 1080)) == .r21x9)
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 2100, height: 900)) == .r21x9)
+    }
+
+    @Test("Cinematic portrait maps to 9:21")
+    func cinematicPortrait() {
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 1080, height: 2520)) == .r9x21)
+    }
+
+    @Test("3:2 and 2:3 ratios map exactly")
+    func r3x2And2x3() {
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 1500, height: 1000)) == .r3x2)
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 1000, height: 1500)) == .r2x3)
+    }
+
+    @Test("4:5 and 5:4 ratios map exactly")
+    func r4x5And5x4() {
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 1000, height: 1250)) == .r4x5)
+        #expect(StabilityAspectRatio.nearest(to: ImageResolution(width: 1250, height: 1000)) == .r5x4)
+    }
+}
+
+@Suite("StabilityImageResolutionValidator")
+struct StabilityImageResolutionValidatorTests {
+
+    private let validator = StabilityImageResolutionValidator()
+
+    @Test("Square resolution passes")
+    func squareValid() throws {
+        try validator.validateResolution(ImageResolution(width: 1024, height: 1024))
+    }
+
+    @Test("21:9 and 9:21 pass at the boundaries")
+    func extremeValid() throws {
+        try validator.validateResolution(ImageResolution(width: 21, height: 9))
+        try validator.validateResolution(ImageResolution(width: 9, height: 21))
+    }
+
+    @Test("Zero width is rejected")
+    func zeroWidthThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            try validator.validateResolution(ImageResolution(width: 0, height: 1024))
+        }
+    }
+
+    @Test("Zero height is rejected")
+    func zeroHeightThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            try validator.validateResolution(ImageResolution(width: 1024, height: 0))
+        }
+    }
+
+    @Test("Ratio more extreme than 21:9 is rejected")
+    func tooWideThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            try validator.validateResolution(ImageResolution(width: 5000, height: 100))
+        }
+    }
+
+    @Test("Ratio more extreme than 9:21 is rejected")
+    func tooTallThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            try validator.validateResolution(ImageResolution(width: 100, height: 5000))
+        }
+    }
+}

--- a/Tests/Stability/StabilityRequestBodyTests.swift
+++ b/Tests/Stability/StabilityRequestBodyTests.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+@Suite("Stability request body encoding")
+struct StabilityRequestBodyTests {
+
+    private func encodeToDictionary(_ body: StabilityImageRequestBody) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(body)
+        let json = try JSONSerialization.jsonObject(with: data, options: [])
+        return try #require(json as? [String: Any])
+    }
+
+    @Test("Core/Ultra body: only prompt and output_format are present")
+    func minimalCoreBody() throws {
+        let body = StabilityImageRequestBody.textToImage(
+            prompt: "hello",
+            negativePrompt: nil,
+            aspectRatio: nil,
+            seed: nil,
+            mode: nil
+        )
+        let dict = try encodeToDictionary(body)
+
+        #expect(dict["prompt"] as? String == "hello")
+        #expect(dict["output_format"] as? String == "png")
+        #expect(dict["negative_prompt"] == nil)
+        #expect(dict["aspect_ratio"] == nil)
+        #expect(dict["seed"] == nil)
+        #expect(dict["mode"] == nil)
+    }
+
+    @Test("Aspect ratio is encoded when set")
+    func encodesAspectRatio() throws {
+        let body = StabilityImageRequestBody.textToImage(
+            prompt: "hello",
+            negativePrompt: nil,
+            aspectRatio: .r16x9,
+            seed: nil,
+            mode: nil
+        )
+        let dict = try encodeToDictionary(body)
+        #expect(dict["aspect_ratio"] as? String == "16:9")
+    }
+
+    @Test("Seed is encoded when set")
+    func encodesSeed() throws {
+        let body = StabilityImageRequestBody.textToImage(
+            prompt: "hello",
+            negativePrompt: nil,
+            aspectRatio: nil,
+            seed: 42,
+            mode: nil
+        )
+        let dict = try encodeToDictionary(body)
+        #expect(dict["seed"] as? Int == 42)
+    }
+
+    @Test("SD 3.5 body includes negative_prompt and mode")
+    func sd35Body() throws {
+        let body = StabilityImageRequestBody.textToImage(
+            prompt: "hello",
+            negativePrompt: "blurry",
+            aspectRatio: .r1x1,
+            seed: 7,
+            mode: "text-to-image"
+        )
+        let dict = try encodeToDictionary(body)
+
+        #expect(dict["prompt"] as? String == "hello")
+        #expect(dict["negative_prompt"] as? String == "blurry")
+        #expect(dict["mode"] as? String == "text-to-image")
+        #expect(dict["aspect_ratio"] as? String == "1:1")
+        #expect(dict["seed"] as? Int == 7)
+        #expect(dict["output_format"] as? String == "png")
+    }
+
+    @Test("output_format is always present and equal to png")
+    func outputFormatIsAlwaysPng() throws {
+        let body = StabilityImageRequestBody.textToImage(
+            prompt: "x",
+            negativePrompt: nil,
+            aspectRatio: nil,
+            seed: nil,
+            mode: nil
+        )
+        let dict = try encodeToDictionary(body)
+        #expect(dict["output_format"] as? String == "png")
+    }
+}

--- a/Tests/Stability/StabilityResponseBodyTests.swift
+++ b/Tests/Stability/StabilityResponseBodyTests.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+@Suite("Stability response body decoding")
+struct StabilityResponseBodyTests {
+
+    private static let onePixelPNGBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+
+    @Test("Decodes images, seeds, and finish_reasons")
+    func decodesValidPayload() throws {
+        let json = """
+            {
+                "seeds": [42],
+                "finish_reasons": [null],
+                "images": ["\(Self.onePixelPNGBase64)"]
+            }
+            """.data(using: .utf8)!
+
+        let body = try JSONDecoder().decode(StabilityImageResponseBody.self, from: json)
+        let output = body.getGeneratedImage()
+
+        #expect(output.images.count == 1)
+        let original = Data(base64Encoded: Self.onePixelPNGBase64)!
+        #expect(output.images.first == original)
+    }
+
+    @Test("Malformed base64 yields no decoded images")
+    func malformedBase64() throws {
+        let json = """
+            {
+                "seeds": [0],
+                "finish_reasons": [null],
+                "images": ["@@@not-valid-base64@@@"]
+            }
+            """.data(using: .utf8)!
+
+        let body = try JSONDecoder().decode(StabilityImageResponseBody.self, from: json)
+        let output = body.getGeneratedImage()
+        #expect(output.images.isEmpty)
+    }
+
+    @Test("Missing optional fields decode to nil")
+    func missingOptionals() throws {
+        let json = """
+            { "images": ["\(Self.onePixelPNGBase64)"] }
+            """.data(using: .utf8)!
+
+        let body = try JSONDecoder().decode(StabilityImageResponseBody.self, from: json)
+        #expect(body.seeds == nil)
+        #expect(body.finishReasons == nil)
+        #expect(body.images.count == 1)
+    }
+}

--- a/Tests/StabilityTestConstants.swift
+++ b/Tests/StabilityTestConstants.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import BedrockService
+
+enum StabilityTestConstants {
+
+    static let imageGenerationModels: [BedrockModel] = [
+        BedrockModel.stable_image_core,
+        BedrockModel.stable_image_ultra,
+        BedrockModel.sd3_5_large,
+    ]
+
+    static let modelsRejectingNegativePrompt: [BedrockModel] = [
+        BedrockModel.stable_image_core,
+        BedrockModel.stable_image_ultra,
+    ]
+
+    static let modelAcceptingNegativePrompt: BedrockModel = BedrockModel.sd3_5_large
+
+    enum ImageGeneration {
+        static let validNrOfImagesNonNil = [1]
+        static let invalidNrOfImages = [-1, 0, 2, 5]
+        static let invalidCfgScale: [Double] = [1.0, 5.0, 10.0]
+        static let validSeed = [0, 1, 12, 4_294_967_295]
+        static let invalidSeed = [-1, 4_294_967_296]
+        static let validImagePrompts = [
+            "This is a test",
+            "!@#$%^&*()_+{}|:<>?",
+            String(repeating: "x", count: 10_000),
+        ]
+        static let invalidImagePrompts = [
+            "", " ", " \n  ", "\t",
+            String(repeating: "x", count: 10_001),
+        ]
+    }
+}

--- a/parameter_cheatsheet.md
+++ b/parameter_cheatsheet.md
@@ -226,3 +226,41 @@
 | negativePrompt | 512       |
 | colors         | 10        |
 
+### Stability AI
+
+[user guide](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-stability-diffusion.html)
+
+Stability models on Bedrock are available in `us-west-2` only. They generate
+exactly **one image per call** (no `numberOfImages` field). They do not accept
+`cfgScale` or `quality`. Resolutions are expressed via `aspect_ratio`; the
+library maps `ImageResolution` to the closest supported ratio.
+
+Supported aspect ratios: `16:9`, `1:1`, `21:9`, `2:3`, `3:2`, `4:5`, `5:4`,
+`9:16`, `9:21`.
+
+#### Common to all Stability models
+
+| parameter  | minValue | maxValue      | defaultValue |
+| ---------- | -------- | ------------- | ------------ |
+| nrOfImages | 1        | 1             | 1            |
+| seed       | 0        | 4_294_967_295 | 0            |
+
+| parameter | supported |
+| --------- | --------- |
+| cfgScale  | no        |
+| quality   | no        |
+
+#### `stability.stable-image-core-v1:1` / `stability.stable-image-ultra-v1:1`
+
+| parameter      | maxLength | supported |
+| -------------- | --------- | --------- |
+| prompt         | 10_000    | yes       |
+| negativePrompt | -         | no        |
+
+#### `stability.sd3-5-large-v1:0`
+
+| parameter      | maxLength | supported |
+| -------------- | --------- | --------- |
+| prompt         | 10_000    | yes       |
+| negativePrompt | 10_000    | yes       |
+


### PR DESCRIPTION
## Summary
- Add three Stability AI text-to-image models on Amazon Bedrock: `stable_image_core` (`stability.stable-image-core-v1:1`), `stable_image_ultra` (`stability.stable-image-ultra-v1:1`), and `sd3_5_large` (`stability.sd3-5-large-v1:0`). All available in `us-west-2`.
- Implemented as a new `StabilityImage` modality conforming to the existing `ImageModality` and `TextToImageModality` protocols, so the public `BedrockService.generateImage(...)` signature is unchanged. `ImageResolution` is mapped internally to the closest supported `aspect_ratio` (16:9, 1:1, 21:9, 2:3, 3:2, 4:5, 5:4, 9:16, 9:21).
- Stability-specific constraints are surfaced as clear `BedrockLibraryError.notSupported` errors rather than silent ignores: `nrOfImages` must be 1, `cfgScale` and `quality` are rejected, and `negativePrompt` is allowed only on `sd3_5_large`.
- Image-to-image for `sd3_5_large` is intentionally deferred and tracked as a follow-up.

## Changes
- **New sources** (`Sources/BedrockService/Models/Stability/`): `StabilityAspectRatio`, `StabilityImageResolutionValidator`, `StabilityImageRequestBody`, `StabilityImageResponseBody`, `StabilityImage` modality, and `StabilityBedrockModels` registering the three models.
- Added `public init(width:height:)` to `ImageResolution` (was synthesized-only and unreachable from outside the module).
- Wired the new models into `BedrockModel.init?(rawValue:)` and added a `Stability Image Generation` branch to `MockBedrockRuntimeClient.invokeModel(...)`.
- **Tests**: end-to-end through `bedrock.generateImage`, request-body encoding (key omission rules), response-body base64 decoding (incl. malformed input), aspect-ratio mapping, and resolution validator boundaries.
- **Docs**: new DocC article `StabilityImageGeneration.md`, cross-linked from the existing `ImageGeneration.md`. New "Stability AI" section in `parameter_cheatsheet.md`.
- **Example**: new `Examples/stability-image/` standalone package; added to the `examples` matrix in `.github/workflows/pull_request.yml`.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 138 tests in 8 suites pass locally
- [x] `swift build` from `Examples/stability-image/` — clean
- [x] `make format` — applied
- [x] CI builds the new example via the integration-tests matrix
- [x] Manual run in `us-west-2` against Bedrock to confirm a PNG is decoded into `Data` (requires AWS credentials)