### PR TITLE
Add structured output support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,7 +109,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'api-key', 'converse', 'converse-stream', 'embeddings', 'openai', 'retrieve', 'text_chat', 'stability-image' ]"
+      examples: "[ 'api-key', 'converse', 'converse-stream', 'embeddings', 'openai', 'retrieve', 'stability-image', 'structured-output', 'text_chat' ]"
 
   swift-6-language-mode:
     name: Swift 6 Language Mode

--- a/.kiro/specs/structured-output/.config.kiro
+++ b/.kiro/specs/structured-output/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "bef718b2-d21a-4983-989e-75d876de6a39", "workflowType": "design-first", "specType": "feature"}

--- a/.kiro/specs/structured-output/design.md
+++ b/.kiro/specs/structured-output/design.md
@@ -1,0 +1,625 @@
+# Design Document: Structured Output
+
+## Overview
+
+This feature adds support for Amazon Bedrock's structured output capability to the Swift Bedrock Library. Structured outputs use constrained decoding to guarantee model responses conform to a specified JSON schema, enabling reliable machine-readable responses.
+
+The feature introduces two mechanisms:
+1. **JSON Schema output format** — Controls the model's response format via `outputConfig.textFormat` in the Converse API, forcing the model to produce JSON conforming to a user-defined schema.
+2. **Strict tool use** — Validates tool input parameters against their schema by adding `strict: true` to tool definitions, ensuring tool calls always produce valid inputs.
+
+Both mechanisms integrate into the existing `ConverseRequestBuilder` fluent API pattern, maintaining consistency with the library's current design philosophy.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "Public API Layer"
+        CRB[ConverseRequestBuilder]
+        T[Tool]
+    end
+
+    subgraph "New Types"
+        OF[OutputFormat]
+        JSD[JSONSchemaDefinition]
+    end
+
+    subgraph "Internal Layer"
+        CR[ConverseRequest]
+        CSR[ConverseStreamingRequest]
+    end
+
+    subgraph "SDK Translation"
+        CI[ConverseInput]
+        CSI[ConverseStreamInput]
+        TS[ToolSpecification]
+    end
+
+    CRB -->|".withOutputFormat()"| OF
+    CRB -->|".withTool(strict:)"| T
+    OF --> JSD
+    CRB --> CR
+    CR --> CI
+    CR --> CSR
+    CSR --> CSI
+    T -->|"getSDKToolSpecification()"| TS
+    OF -->|"getSDKOutputFormat()"| CI
+    OF -->|"getSDKOutputFormat()"| CSI
+```
+
+## Sequence Diagrams
+
+### JSON Schema Output Format Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CRB as ConverseRequestBuilder
+    participant CR as ConverseRequest
+    participant SDK as AWSBedrockRuntime
+
+    User->>CRB: .withOutputFormat(schema:name:description:)
+    CRB->>CRB: Validate schema is valid JSON
+    CRB->>CRB: Store OutputFormat
+    User->>CRB: .withPrompt("Extract data...")
+    
+    Note over User,CRB: At converse time
+    User->>CRB: bedrockService.converse(with: builder)
+    CRB->>CR: Build ConverseRequest with outputFormat
+    CR->>SDK: ConverseInput(outputFormat: ...)
+    SDK-->>CR: ConverseOutput
+    CR-->>User: ConverseReply (JSON text in textReply)
+```
+
+### Strict Tool Use Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant T as Tool
+    participant CRB as ConverseRequestBuilder
+    participant CR as ConverseRequest
+    participant SDK as AWSBedrockRuntime
+
+    User->>T: Tool(name:inputSchema:description:strict:true)
+    User->>CRB: .withTool(tool)
+    CRB->>CR: Build ConverseRequest with strict tool
+    CR->>SDK: ConverseInput(toolConfig with strict:true)
+    SDK-->>CR: ConverseOutput with validated tool use
+    CR-->>User: ConverseReply with ToolUseBlock
+```
+
+## Components and Interfaces
+
+### Component 1: OutputFormat
+
+**Purpose**: Represents the structured output configuration for the Converse API. Encapsulates the JSON schema definition that constrains model output.
+
+```swift
+public struct OutputFormat: Codable, Sendable {
+    public let schema: JSON
+    public let name: String
+    public let description: String?
+
+    public init(schema: JSON, name: String, description: String? = nil) throws
+    public init(schema: String, name: String, description: String? = nil) throws
+    public init<T: Encodable>(from type: T.Type, name: String, description: String? = nil) throws
+
+    func getSDKOutputFormat() throws -> BedrockRuntimeClientTypes.OutputFormat
+}
+```
+
+**Responsibilities**:
+- Validate that the provided schema is valid JSON
+- Validate that the name is non-empty and conforms to naming rules
+- Convert to the SDK's `OutputFormat` type for API calls
+- Provide convenience initializers for common use cases (JSON string, `JSON` type, Encodable type)
+
+### Component 2: Tool (Extended)
+
+**Purpose**: Extends the existing `Tool` struct to support the `strict` parameter for constrained tool input validation.
+
+```swift
+public struct Tool: Codable, CustomStringConvertible, Sendable {
+    public let name: String
+    public let inputSchema: JSON
+    public let toolDescription: String?
+    public let strict: Bool  // NEW
+
+    public init(name: String, inputSchema: JSON, description: String? = nil, strict: Bool = false) throws
+    public func getSDKToolSpecification() throws -> BedrockRuntimeClientTypes.ToolSpecification
+}
+```
+
+**Responsibilities**:
+- Store the `strict` flag alongside existing tool properties
+- Pass `strict: true` through to the SDK's `ToolSpecification` when generating the SDK type
+- Default to `strict: false` for backward compatibility
+
+### Component 3: ConverseRequestBuilder (Extended)
+
+**Purpose**: Extends the builder with methods to configure structured output.
+
+```swift
+extension ConverseRequestBuilder {
+    public func withOutputFormat(_ outputFormat: OutputFormat) throws -> ConverseRequestBuilder
+    public func withOutputFormat(schema: JSON, name: String, description: String? = nil) throws -> ConverseRequestBuilder
+    public func withOutputFormat(schema: String, name: String, description: String? = nil) throws -> ConverseRequestBuilder
+}
+```
+
+**Responsibilities**:
+- Validate that the model supports structured output (via `ConverseFeature`)
+- Store the output format configuration
+- Pass it through to `ConverseRequest` at build time
+
+### Component 4: ConverseRequest (Extended)
+
+**Purpose**: Extends the internal request struct to include output format in the SDK input.
+
+```swift
+struct ConverseRequest {
+    // ... existing fields ...
+    let outputFormat: OutputFormat?  // NEW
+
+    func getConverseInput(forRegion region: Region) throws -> ConverseInput
+}
+```
+
+**Responsibilities**:
+- Include `outputFormat` in the `ConverseInput` construction
+- Include `outputFormat` in the `ConverseStreamInput` construction (via the streaming extension)
+
+## Data Models
+
+### OutputFormat
+
+```swift
+public struct OutputFormat: Codable, Sendable {
+    /// The JSON schema that constrains the model's output
+    public let schema: JSON
+    /// A name identifying this schema (used for caching)
+    public let name: String
+    /// An optional description of what the schema represents
+    public let description: String?
+}
+```
+
+**Validation Rules**:
+- `schema` must be valid JSON representing a JSON Schema object
+- `name` must be non-empty
+- `name` must match pattern `[a-zA-Z0-9_-]+`
+- The schema's root must be an object type (Bedrock requirement)
+
+### ConverseFeature (Extended)
+
+```swift
+public enum ConverseFeature: String, Codable, Sendable {
+    case textGeneration = "text-generation"
+    case vision = "vision"
+    case document = "document"
+    case toolUse = "tool-use"
+    case systemPrompts = "system-prompts"
+    case reasoning = "reasoning"
+    case structuredOutput = "structured-output"  // NEW
+}
+```
+
+### SDK Mapping
+
+The `OutputFormat` maps to the Bedrock API structure:
+
+```swift
+// SDK type hierarchy:
+// ConverseInput.outputFormat -> BedrockRuntimeClientTypes.OutputFormat
+//   .type = "json_schema"
+//   .structure -> BedrockRuntimeClientTypes.OutputFormatStructure
+//     .jsonSchema -> BedrockRuntimeClientTypes.JsonSchemaDefinition
+//       .schema = "<json_string>"
+//       .name = "schema_name"
+//       .description = "optional description"
+```
+
+## Algorithmic Pseudocode
+
+### OutputFormat SDK Conversion
+
+```swift
+func getSDKOutputFormat() throws -> BedrockRuntimeClientTypes.OutputFormat {
+    // PRECONDITION: schema is valid JSON, name is non-empty
+    // POSTCONDITION: Returns a valid SDK OutputFormat ready for API call
+
+    let schemaString = try schema.toJSONString()
+
+    let jsonSchemaDefinition = BedrockRuntimeClientTypes.JsonSchemaDefinition(
+        description: self.description,
+        name: self.name,
+        schema: schemaString
+    )
+
+    let structure = BedrockRuntimeClientTypes.OutputFormatStructure.jsonSchema(jsonSchemaDefinition)
+
+    return BedrockRuntimeClientTypes.OutputFormat(
+        structure: structure,
+        type: .jsonSchema
+    )
+}
+```
+
+**Preconditions:**
+- `schema` contains valid JSON that represents a JSON Schema
+- `name` is non-empty and matches `[a-zA-Z0-9_-]+`
+
+**Postconditions:**
+- Returns a fully populated `BedrockRuntimeClientTypes.OutputFormat`
+- The `type` field is always `.jsonSchema`
+- The `schema` field in the definition is a JSON string representation
+
+### Tool SDK Conversion (Updated)
+
+```swift
+func getSDKToolSpecification() throws -> BedrockRuntimeClientTypes.ToolSpecification {
+    // PRECONDITION: name is valid, inputSchema is valid JSON
+    // POSTCONDITION: Returns ToolSpecification with strict flag when set
+
+    return BedrockRuntimeClientTypes.ToolSpecification(
+        description: toolDescription,
+        inputSchema: .json(try inputSchema.toDocument()),
+        name: name,
+        strict: strict ? true : nil  // Only pass when true
+    )
+}
+```
+
+**Preconditions:**
+- `name` is non-empty and matches `[a-zA-Z0-9_-]+`
+- `inputSchema` is valid JSON convertible to a Smithy Document
+
+**Postconditions:**
+- Returns `ToolSpecification` with `strict` set to `true` when enabled
+- When `strict` is `false`, `strict` is passed as `nil` (omitted from request)
+
+### ConverseInput Construction (Updated)
+
+```swift
+func getConverseInput(forRegion region: Region) throws -> ConverseInput {
+    // PRECONDITION: All request fields are validated
+    // POSTCONDITION: Returns complete ConverseInput with outputFormat when set
+
+    return ConverseInput(
+        additionalModelRequestFields: try getAdditionalModelRequestFields(),
+        inferenceConfig: inferenceConfig?.getSDKInferenceConfig(),
+        messages: try getSDKMessages(),
+        modelId: model.getModelIdWithCrossRegionInferencePrefix(region: region),
+        outputFormat: try outputFormat?.getSDKOutputFormat(),  // NEW
+        serviceTier: BedrockRuntimeClientTypes.ServiceTier(type: .init(rawValue: serviceTier.rawValue)),
+        system: getSDKSystemPrompts(),
+        toolConfig: try toolConfig?.getSDKToolConfig()
+    )
+}
+```
+
+**Preconditions:**
+- Model ID is valid
+- Messages are properly formatted
+- OutputFormat (if set) has been validated
+
+**Postconditions:**
+- Returns `ConverseInput` with all fields populated
+- `outputFormat` is included only when explicitly configured
+- All other existing fields remain unchanged
+
+### Builder withOutputFormat Validation
+
+```swift
+func withOutputFormat(_ outputFormat: OutputFormat) throws -> ConverseRequestBuilder {
+    // PRECONDITION: outputFormat is a valid OutputFormat instance
+    // POSTCONDITION: Returns new builder with outputFormat set
+
+    try validateFeature(.structuredOutput)
+
+    var copy = self
+    copy.outputFormat = outputFormat
+    return copy
+}
+```
+
+**Preconditions:**
+- The model supports the `.structuredOutput` converse feature
+- `outputFormat` has been constructed with valid schema and name
+
+**Postconditions:**
+- Returns a new builder instance with `outputFormat` stored
+- Original builder is unchanged (value semantics)
+
+## Key Functions with Formal Specifications
+
+### OutputFormat.init(schema:name:description:)
+
+```swift
+public init(schema: JSON, name: String, description: String? = nil) throws
+```
+
+**Preconditions:**
+- `schema` is a valid `JSON` value (not `.null`)
+- `name` is non-empty
+- `name` matches regex `[a-zA-Z0-9_-]+`
+
+**Postconditions:**
+- Returns a valid `OutputFormat` instance
+- Throws `BedrockLibraryError.invalidName` if name is empty or invalid
+- Throws `BedrockLibraryError.invalid` if schema is null
+
+**Loop Invariants:** N/A
+
+### OutputFormat.init(schema:name:description:) (String variant)
+
+```swift
+public init(schema: String, name: String, description: String? = nil) throws
+```
+
+**Preconditions:**
+- `schema` is a valid JSON string
+- `name` is non-empty and matches `[a-zA-Z0-9_-]+`
+
+**Postconditions:**
+- Returns a valid `OutputFormat` instance with parsed JSON schema
+- Throws `BedrockLibraryError.decodingError` if schema string is not valid JSON
+- Throws `BedrockLibraryError.invalidName` if name is invalid
+
+**Loop Invariants:** N/A
+
+### Tool.init(name:inputSchema:description:strict:)
+
+```swift
+public init(name: String, inputSchema: JSON, description: String? = nil, strict: Bool = false) throws
+```
+
+**Preconditions:**
+- `name` is non-empty
+- `name` matches `[a-zA-Z0-9_-]+`
+- `inputSchema` is valid JSON
+
+**Postconditions:**
+- Returns a `Tool` with `strict` property set
+- Backward compatible: existing callers without `strict` parameter get `false`
+- Throws same errors as current implementation for invalid name
+
+**Loop Invariants:** N/A
+
+### ConverseRequestBuilder.withOutputFormat(_:)
+
+```swift
+public func withOutputFormat(_ outputFormat: OutputFormat) throws -> ConverseRequestBuilder
+```
+
+**Preconditions:**
+- Model supports `.structuredOutput` feature
+- `outputFormat` is a valid instance
+
+**Postconditions:**
+- Returns new builder with `outputFormat` stored
+- Throws `BedrockLibraryError.invalidModality` if model doesn't support structured output
+- Original builder is unchanged
+
+**Loop Invariants:** N/A
+
+## Example Usage
+
+```swift
+// Example 1: JSON Schema output format with builder pattern
+let schema = try JSON(from: """
+{
+    "type": "object",
+    "properties": {
+        "name": { "type": "string" },
+        "age": { "type": "integer" },
+        "email": { "type": "string", "format": "email" }
+    },
+    "required": ["name", "age", "email"],
+    "additionalProperties": false
+}
+""")
+
+let builder = try ConverseRequestBuilder(with: .claude3_5_sonnet)
+    .withPrompt("Extract the person's info from: John Doe, 30 years old, john@example.com")
+    .withOutputFormat(schema: schema, name: "person_info", description: "Person information")
+
+let reply = try await bedrockService.converse(with: builder)
+let jsonText = try reply.getTextReply()  // Guaranteed valid JSON matching schema
+
+// Example 2: Strict tool use
+let tool = try Tool(
+    name: "get_weather",
+    inputSchema: try JSON(from: """
+    {
+        "type": "object",
+        "properties": {
+            "location": { "type": "string" },
+            "unit": { "type": "string", "enum": ["celsius", "fahrenheit"] }
+        },
+        "required": ["location", "unit"],
+        "additionalProperties": false
+    }
+    """),
+    description: "Get weather for a location",
+    strict: true
+)
+
+let builder = try ConverseRequestBuilder(with: .claude3_5_sonnet)
+    .withPrompt("What's the weather in Paris?")
+    .withTool(tool)
+
+let reply = try await bedrockService.converse(with: builder)
+let toolUse = try reply.getToolUse()  // Tool input guaranteed to match schema
+
+// Example 3: Using OutputFormat directly
+let outputFormat = try OutputFormat(
+    schema: schema,
+    name: "extraction_result",
+    description: "Structured extraction result"
+)
+
+let builder = try ConverseRequestBuilder(with: .claude3_5_sonnet)
+    .withPrompt("Analyze this text...")
+    .withOutputFormat(outputFormat)
+
+// Example 4: Streaming with structured output
+let builder = try ConverseRequestBuilder(with: .claude3_5_sonnet)
+    .withPrompt("List 3 books as JSON")
+    .withOutputFormat(schema: bookListSchema, name: "book_list")
+
+let stream = try await bedrockService.converseStream(with: builder)
+for try await element in stream.stream {
+    switch element {
+    case .text(let delta):
+        print(delta, terminator: "")  // Partial JSON streamed
+    case .messageComplete(let message):
+        // Full message available, text is valid JSON
+        break
+    default:
+        break
+    }
+}
+
+// Example 5: Checking stop reason for conformance
+let reply = try await bedrockService.converse(with: builder)
+let lastMessage = reply.getLastMessage()
+if lastMessage.stopReason == .endTurn {
+    // Response conforms to schema
+    let json = try reply.getTextReply()
+} else if lastMessage.stopReason == .maxTokens {
+    // Response may be truncated and not conform to schema
+    // Handle gracefully
+}
+```
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system-essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Backward Compatibility
+
+*For any* existing code using `Tool(name:inputSchema:description:)`, the behavior is unchanged — `strict` defaults to `false` and is omitted from the SDK request.
+
+**Validates: Requirements 3.2, 3.4, 3.5**
+
+### Property 2: Schema Preservation
+
+*For any* valid JSON schema `s` and valid name `n`, creating `OutputFormat(schema: s, name: n)` and calling `getSDKOutputFormat()` SHALL produce a JsonSchemaDefinition whose schema field, when parsed back to JSON, is semantically equivalent to `s`.
+
+**Validates: Requirements 1.2, 1.3, 2.2**
+
+### Property 3: Name Validation Consistency
+
+*For any* string `s`, the OutputFormat name validation and Tool name validation SHALL produce the same accept/reject result — both use the pattern `[a-zA-Z0-9_-]+` and reject empty strings.
+
+**Validates: Requirements 7.1, 7.2**
+
+### Property 4: Feature Gating
+
+*For any* model `m` where `m.hasConverseModality(.structuredOutput) == false`, calling `withOutputFormat()` on a builder for that model SHALL throw `BedrockLibraryError.invalidModality`.
+
+**Validates: Requirements 4.5, 6.2, 6.3**
+
+### Property 5: Nil Propagation
+
+*For any* ConverseRequest where `outputFormat` is nil, the `outputFormat` field in the resulting `ConverseInput` (and `ConverseStreamInput` for streaming) SHALL be nil.
+
+**Validates: Requirements 5.2, 5.3**
+
+### Property 6: Strict Tool Mapping
+
+*For any* Tool with `strict == true`, `getSDKToolSpecification().strict` SHALL be `true`. *For any* Tool with `strict == false`, `getSDKToolSpecification().strict` SHALL be `nil`.
+
+**Validates: Requirements 3.3, 3.4**
+
+### Property 7: Immutable Builder
+
+*For any* builder `b` and valid OutputFormat `f`, calling `b.withOutputFormat(f)` SHALL return a new builder with the format set, and `b` SHALL remain unchanged (no outputFormat stored).
+
+**Validates: Requirements 4.6, 4.7**
+
+## Error Handling
+
+### Error Scenario 1: Invalid Schema JSON
+
+**Condition**: User provides a malformed JSON string to `OutputFormat.init(schema: String, ...)`
+**Response**: Throws `BedrockLibraryError.decodingError("Failed to decode JSON: ...")`
+**Recovery**: User fixes the JSON string and retries
+
+### Error Scenario 2: Unsupported Model
+
+**Condition**: User calls `withOutputFormat()` on a model that doesn't support structured output
+**Response**: Throws `BedrockLibraryError.invalidModality(model, modality, "This model does not support converse feature structuredOutput.")`
+**Recovery**: User selects a supported model
+
+### Error Scenario 3: Empty or Invalid Name
+
+**Condition**: User provides empty string or invalid characters for schema name
+**Response**: Throws `BedrockLibraryError.invalidName("OutputFormat name is not allowed to be empty")` or `BedrockLibraryError.invalidName("OutputFormat name must consist of only...")`
+**Recovery**: User provides a valid name
+
+### Error Scenario 4: Non-Conforming Response (Runtime)
+
+**Condition**: Model returns a response that doesn't conform to schema (e.g., due to `maxTokens` truncation or content filtering)
+**Response**: The library returns the response as-is. The `stopReason` on the message indicates why the response may not conform (`.maxTokens`, `.contentFiltered`, `.guardrailIntervened`).
+**Recovery**: User checks `stopReason` before parsing the JSON response. Only `.endTurn` guarantees conformance.
+
+### Error Scenario 5: Null Schema
+
+**Condition**: User provides a `.null` JSON value as schema
+**Response**: Throws `BedrockLibraryError.invalid("OutputFormat schema must not be null")`
+**Recovery**: User provides a valid JSON schema object
+
+## Testing Strategy
+
+### Unit Testing Approach
+
+- Test `OutputFormat` initialization with valid and invalid inputs
+- Test `OutputFormat.getSDKOutputFormat()` produces correct SDK types
+- Test `Tool` with `strict: true` produces correct `ToolSpecification`
+- Test `Tool` with `strict: false` (default) omits strict from `ToolSpecification`
+- Test `ConverseRequestBuilder.withOutputFormat()` stores the format correctly
+- Test `ConverseRequestBuilder.withOutputFormat()` throws for unsupported models
+- Test `ConverseRequest.getConverseInput()` includes `outputFormat` when set
+- Test `ConverseRequest.getConverseInput()` excludes `outputFormat` when nil
+- Test streaming request also includes `outputFormat`
+- Test backward compatibility: existing `Tool` initializer still works without `strict`
+- Test name validation matches existing `Tool` name validation rules
+- Test `ConverseRequestBuilder(from:)` copies `outputFormat` correctly
+
+### Property-Based Testing Approach
+
+**Property Test Library**: Swift Testing with custom generators
+
+- For any valid JSON schema string, `OutputFormat(schema:name:)` followed by `getSDKOutputFormat()` produces a non-nil result
+- For any `Tool` with `strict: true`, `getSDKToolSpecification().strict == true`
+- For any `Tool` with `strict: false`, `getSDKToolSpecification().strict == nil`
+- Builder immutability: for any builder `b`, `b.withOutputFormat(f)` does not mutate `b`
+
+### Integration Testing Approach
+
+- End-to-end test with a real Bedrock model that supports structured output
+- Verify the response text is valid JSON conforming to the provided schema
+- Test with strict tool use and verify tool input parameters match schema
+- Test streaming with structured output produces valid JSON when assembled
+
+## Performance Considerations
+
+- Grammar compilation on first request may add latency (Bedrock-side, 24-hour cache per account)
+- No additional memory overhead beyond storing the `OutputFormat` struct (small: one `JSON` value + two strings)
+- Schema serialization to JSON string happens once at request build time
+- No impact on response parsing — text reply is still a string, user handles JSON decoding
+
+## Security Considerations
+
+- JSON schemas are passed as strings to the API; no code execution occurs locally
+- Schema content is not validated against Bedrock's supported subset locally — invalid schemas will produce API errors at runtime
+- No secrets or credentials are involved in the structured output configuration
+
+## Dependencies
+
+- `AWSBedrockRuntime` — Must support `OutputFormat`, `OutputFormatStructure`, `JsonSchemaDefinition` types in `ConverseInput` and `ConverseStreamInput`, and `strict` field on `ToolSpecification`
+- `Smithy` — Used for Document type conversion (existing dependency)
+- No new external dependencies required

--- a/.kiro/specs/structured-output/requirements.md
+++ b/.kiro/specs/structured-output/requirements.md
@@ -1,0 +1,173 @@
+# Requirements Document
+
+## Introduction
+
+This document defines the requirements for adding structured output support to the Swift Bedrock Library. Structured output enables developers to constrain model responses to conform to a specified JSON schema, producing reliable machine-readable output. The feature provides two mechanisms: JSON schema output format (via the Converse API's `outputConfig.textFormat`) and strict tool use (via `strict: true` on tool definitions). The feature also includes a demonstration example app and DocC documentation for library consumers.
+
+## Glossary
+
+- **OutputFormat**: A struct representing the structured output configuration, encapsulating a JSON schema, name, and optional description.
+- **Tool**: An existing struct representing a tool definition for function calling, extended with a `strict` parameter.
+- **ConverseRequestBuilder**: The fluent builder API used to construct Converse API requests.
+- **ConverseRequest**: The internal request struct that translates builder configuration into SDK input types.
+- **ConverseFeature**: An enum representing capabilities supported by a given Bedrock model (e.g., text generation, vision, tool use, structured output).
+- **BedrockModel**: An enum representing available Amazon Bedrock foundation models.
+- **JSON**: A library type representing parsed JSON values.
+- **BedrockService**: The main service class that executes Converse API calls against Amazon Bedrock.
+- **ConverseReply**: The response type returned from a Converse API call.
+- **StopReason**: An enum indicating why the model stopped generating (e.g., endTurn, maxTokens, contentFiltered).
+- **DocC**: Apple's documentation compiler for generating developer documentation from Swift source code and markdown articles.
+
+## Requirements
+
+### Requirement 1: OutputFormat Type
+
+**User Story:** As a developer, I want to define a JSON schema that constrains model output, so that I can receive guaranteed machine-readable responses conforming to my expected structure.
+
+#### Acceptance Criteria
+
+1. THE OutputFormat struct SHALL store a JSON schema as a JSON value, a name as a String, and an optional description as a String
+2. WHEN an OutputFormat is initialized with a JSON value that is not null and a name matching the pattern `[a-zA-Z0-9_-]+`, THE OutputFormat SHALL be created successfully with the schema, name, and description stored
+3. WHEN an OutputFormat is initialized with a syntactically valid JSON string and a name matching the pattern `[a-zA-Z0-9_-]+`, THE OutputFormat SHALL parse the string into a JSON value and create the instance successfully
+4. IF an OutputFormat is initialized with a null JSON value, THEN THE OutputFormat SHALL throw a BedrockLibraryError.invalid error
+5. IF an OutputFormat is initialized with a string that is not syntactically valid JSON, THEN THE OutputFormat SHALL throw a BedrockLibraryError.decodingError
+6. IF an OutputFormat is initialized with an empty name, THEN THE OutputFormat SHALL throw a BedrockLibraryError.invalidName error
+7. IF an OutputFormat is initialized with a name containing characters outside the pattern `[a-zA-Z0-9_-]+`, THEN THE OutputFormat SHALL throw a BedrockLibraryError.invalidName error
+8. THE OutputFormat SHALL conform to Codable and Sendable protocols
+
+### Requirement 2: OutputFormat SDK Conversion
+
+**User Story:** As a developer, I want the OutputFormat to translate correctly into the Bedrock SDK types, so that the API receives the proper structured output configuration.
+
+#### Acceptance Criteria
+
+1. WHEN getSDKOutputFormat() is called on a valid OutputFormat, THE OutputFormat SHALL return a BedrockRuntimeClientTypes.OutputFormat with type set to .jsonSchema and structure set to .jsonSchema containing a JsonSchemaDefinition
+2. WHEN getSDKOutputFormat() is called, THE OutputFormat SHALL serialize the schema as a JSON string in the JsonSchemaDefinition such that parsing the string back to JSON produces a value semantically equivalent to the original schema
+3. WHEN getSDKOutputFormat() is called, THE OutputFormat SHALL set the name field of the JsonSchemaDefinition to the OutputFormat's name value
+4. WHEN getSDKOutputFormat() is called on an OutputFormat with a description, THE OutputFormat SHALL set the description field of the JsonSchemaDefinition to the OutputFormat's description value
+5. WHEN getSDKOutputFormat() is called on an OutputFormat without a description, THE OutputFormat SHALL set description to nil in the JsonSchemaDefinition
+6. IF the schema cannot be serialized to a JSON string (whether by throwing an error or producing an empty/nil result), THEN THE OutputFormat SHALL throw an error from getSDKOutputFormat()
+
+### Requirement 3: Tool Strict Parameter
+
+**User Story:** As a developer, I want to mark tools as strict, so that the model validates tool input parameters against their schema and guarantees conforming tool calls.
+
+#### Acceptance Criteria
+
+1. THE Tool struct SHALL include a public strict property of type Bool that conforms to Codable and Sendable
+2. WHEN a Tool is initialized without specifying the strict parameter, THE Tool SHALL default strict to false
+3. WHEN a Tool with strict set to true calls getSDKToolSpecification(), THE Tool SHALL set the strict field to true on the resulting ToolSpecification
+4. WHEN a Tool with strict set to false calls getSDKToolSpecification(), THE Tool SHALL set the strict field to nil on the resulting ToolSpecification
+5. WHEN existing code uses the Tool initializer without the strict parameter, THE Tool SHALL compile without modification; recompilation of dependent code is acceptable but no source changes SHALL be required
+6. WHEN a Tool is initialized from a SDK ToolSpecification that has strict set to true, THE Tool SHALL set its strict property to true
+7. WHEN a Tool is initialized from a SDK ToolSpecification that has strict set to nil or false, THE Tool SHALL set its strict property to false
+
+### Requirement 4: ConverseRequestBuilder Structured Output Integration
+
+**User Story:** As a developer, I want to configure structured output through the fluent builder API, so that I can use the same familiar pattern for all Converse API features.
+
+#### Acceptance Criteria
+
+1. THE ConverseRequestBuilder SHALL provide a withOutputFormat method that accepts an OutputFormat instance and returns a new ConverseRequestBuilder
+2. THE ConverseRequestBuilder SHALL provide a convenience withOutputFormat method that accepts schema as JSON, name as String, and an optional description as String
+3. THE ConverseRequestBuilder SHALL provide a convenience withOutputFormat method that accepts schema as String, name as String, and an optional description as String
+4. WHEN withOutputFormat is called on a builder for a model that supports the structuredOutput converse feature, THE ConverseRequestBuilder SHALL create a genuinely new copied builder object whose outputFormat property is set to the provided OutputFormat value
+5. IF withOutputFormat is called on a builder for a model that does not support the structuredOutput converse feature, THEN THE ConverseRequestBuilder SHALL throw a BedrockLibraryError.invalidModality error without modifying the original builder
+6. WHEN withOutputFormat is called, THE ConverseRequestBuilder SHALL not mutate the original builder instance, leaving its outputFormat property unchanged
+7. WHEN a ConverseRequestBuilder is copied via any init(from:) initializer, THE ConverseRequestBuilder SHALL preserve the outputFormat configuration from the source builder
+8. WHEN withOutputFormat is called multiple times on the same builder chain, THE ConverseRequestBuilder SHALL use the OutputFormat from the most recent call
+9. WHEN a ConverseRequest is built from a ConverseRequestBuilder that has an outputFormat set, THE ConverseRequestBuilder SHALL include the outputFormat in the resulting ConverseInput and ConverseStreamInput passed to the SDK
+
+### Requirement 5: ConverseRequest Output Format Propagation
+
+**User Story:** As a developer, I want the output format to be included in the API request, so that the Bedrock service applies the schema constraint to the model response.
+
+#### Acceptance Criteria
+
+1. WHEN a ConverseRequest has an outputFormat set, THE ConverseRequest SHALL include the result of calling getSDKOutputFormat() on the OutputFormat as the outputFormat parameter of the ConverseInput
+2. WHEN a ConverseRequest has no outputFormat set, THE ConverseRequest SHALL set the outputFormat parameter to nil in the ConverseInput
+3. WHEN a streaming ConverseRequest has an outputFormat set, THE ConverseRequest SHALL include the result of calling getSDKOutputFormat() on the OutputFormat as the outputFormat parameter of the ConverseStreamInput
+4. WHEN a streaming ConverseRequest has no outputFormat set, THE ConverseRequest SHALL set the outputFormat parameter to nil in the ConverseStreamInput
+
+### Requirement 6: ConverseFeature Extension
+
+**User Story:** As a developer, I want to check whether a model supports structured output, so that I can handle unsupported models gracefully.
+
+#### Acceptance Criteria
+
+1. THE ConverseFeature enum SHALL include a structuredOutput case with raw value "structured-output"
+2. IF a model's converseFeatures array contains .structuredOutput, THEN THE BedrockModel SHALL return true for hasConverseModality(.structuredOutput)
+3. IF a model's converseFeatures array does not contain .structuredOutput, THEN THE BedrockModel SHALL return false for hasConverseModality(.structuredOutput)
+4. IF a model does not conform to ConverseModality, THEN THE BedrockModel SHALL return false for hasConverseModality(.structuredOutput)
+
+### Requirement 7: Name Validation Consistency
+
+**User Story:** As a developer, I want consistent naming rules across OutputFormat and Tool, so that I can apply the same naming conventions without confusion.
+
+#### Acceptance Criteria
+
+1. THE OutputFormat name validation SHALL accept only strings matching the pattern [a-zA-Z0-9_-]+ (one or more alphanumeric characters, underscores, or hyphens) using the same matching strategy as Tool name validation
+2. IF the OutputFormat name is an empty string, THEN THE OutputFormat initializer SHALL throw a BedrockLibraryError.invalidName error
+3. IF the OutputFormat name contains characters outside the set [a-zA-Z0-9_-], THEN THE OutputFormat initializer SHALL throw a BedrockLibraryError.invalidName error
+
+### Requirement 8: Response Handling for Structured Output
+
+**User Story:** As a developer, I want to understand when a structured output response may not conform to the schema, so that I can handle edge cases gracefully.
+
+#### Acceptance Criteria
+
+1. WHEN a model response has stopReason of endTurn and structured output was requested, THE ConverseReply SHALL contain text that is valid JSON conforming to the requested JSON schema structure
+2. WHEN a model response has stopReason of maxTokens and structured output was requested, THE ConverseReply SHALL return the response text as-is (even if it is invalid JSON) without throwing an error, and the stopReason SHALL be accessible on the reply so the developer can detect that the output may be truncated and not conform to the schema
+3. WHEN a model response has stopReason of contentFiltered or guardrailIntervened and structured output was requested, THE ConverseReply SHALL return the response text as-is without throwing an error, and the stopReason SHALL be accessible on the reply so the developer can detect that the output may not conform to the schema
+4. THE ConverseReply SHALL expose the stopReason value from the model response so that the developer can programmatically distinguish between conforming responses (endTurn) and potentially non-conforming responses (maxTokens, contentFiltered, guardrailIntervened)
+
+### Requirement 9: Example Application
+
+**User Story:** As a developer, I want a working example application demonstrating structured output, so that I can quickly understand how to use both JSON schema output format and strict tool use in my own projects.
+
+#### Acceptance Criteria
+
+1. THE Example Application SHALL be located in the Examples/ directory with a lowercase-hyphenated directory name, containing a Package.swift file, a Sources/ directory with a Swift source file using the @main struct pattern, and a .gitignore file
+2. THE Example Application SHALL include a Package.swift that depends on the swift-bedrock-library using a local path dependency (`path: "../.."`) and targets macOS 15, iOS 18, and tvOS 18
+3. THE Example Application SHALL demonstrate JSON schema output format by defining a JSON schema with at least 2 properties and at least 1 required field, calling `withOutputFormat` on a ConverseRequestBuilder, and printing the returned JSON text response to standard output
+4. THE Example Application SHALL demonstrate strict tool use by defining a Tool with `strict` set to `true`, sending a converse request with that tool, detecting the ToolUseBlock in the response, and printing the tool name and input parameters to standard output
+5. THE Example Application SHALL use a model that supports the `.structuredOutput` converse feature and SHALL verify support by calling `hasConverseModality` before making requests
+6. IF the selected model does not support structured output, THEN THE Example Application SHALL print an error message indicating the model lacks structured output support and exit without calling the Converse API
+7. IF an error is thrown during schema creation or API invocation, THEN THE Example Application SHALL catch the error and print it to standard output using a do/catch block
+8. THE Example Application SHALL compile without errors using `swift build` and SHALL execute successfully without runtime errors, producing observable printed output for both the JSON schema response and the strict tool use response when run with `swift run`
+
+### Requirement 10: Unit Tests
+
+**User Story:** As a developer, I want comprehensive unit tests covering all new and modified code, so that I can verify correctness and prevent regressions.
+
+#### Acceptance Criteria
+
+1. THE Unit Tests SHALL use the Swift Testing framework (@Test, #expect, #require macros) and be located in the Tests/ directory following the existing test file naming conventions
+2. THE Unit Tests SHALL test OutputFormat initialization with valid JSON values and valid names, verifying the stored schema, name, and description
+3. THE Unit Tests SHALL test OutputFormat initialization failures for null JSON, invalid JSON strings, empty names, and names with invalid characters
+4. THE Unit Tests SHALL test OutputFormat.getSDKOutputFormat() produces a BedrockRuntimeClientTypes.OutputFormat with correct type, structure, schema string, name, and description
+5. THE Unit Tests SHALL test Tool initialization with strict set to true and strict set to false, verifying the stored strict value
+6. THE Unit Tests SHALL test Tool.getSDKToolSpecification() returns strict as true when Tool.strict is true, and strict as nil when Tool.strict is false
+7. THE Unit Tests SHALL test Tool backward compatibility by verifying that Tool(name:inputSchema:description:) without the strict parameter compiles and defaults strict to false
+8. THE Unit Tests SHALL test ConverseRequestBuilder.withOutputFormat() stores the output format on a supported model and throws BedrockLibraryError.invalidModality on an unsupported model
+9. THE Unit Tests SHALL test ConverseRequestBuilder immutability by verifying that calling withOutputFormat does not mutate the original builder
+10. THE Unit Tests SHALL test ConverseRequestBuilder.init(from:) preserves the outputFormat from the source builder
+11. THE Unit Tests SHALL test ConverseRequest.getConverseInput() includes outputFormat in the ConverseInput when set and excludes it when nil
+12. THE Unit Tests SHALL compile and pass when run with `swift test`
+
+### Requirement 11: DocC Documentation
+
+**User Story:** As a library consumer, I want comprehensive DocC documentation explaining structured output, so that I can learn how to use the feature with code samples and best practices.
+
+#### Acceptance Criteria
+
+1. THE DocC Documentation SHALL be added as a markdown article in the Sources/BedrockService/Docs.docc/ directory
+2. THE DocC Documentation SHALL explain both JSON schema output format and strict tool use mechanisms
+3. THE DocC Documentation SHALL include code samples showing OutputFormat creation from JSON, String, and Encodable types
+4. THE DocC Documentation SHALL include code samples showing Tool creation with strict parameter
+5. THE DocC Documentation SHALL include code samples showing the ConverseRequestBuilder fluent API with withOutputFormat
+6. THE DocC Documentation SHALL document best practices for schema design including the additionalProperties constraint
+7. THE DocC Documentation SHALL explain stop reason handling and when responses may not conform to the schema
+8. THE DocC Documentation SHALL include a streaming example with structured output
+9. THE DocC Documentation SHALL include See Also links to related documentation articles (Converse, Tools, Streaming)
+

--- a/.kiro/specs/structured-output/tasks.md
+++ b/.kiro/specs/structured-output/tasks.md
@@ -1,0 +1,195 @@
+# Implementation Plan: Structured Output
+
+## Overview
+
+This plan implements structured output support for the Swift Bedrock Library, adding JSON schema output format and strict tool use capabilities to the Converse API. Implementation proceeds from foundational types through builder integration, request propagation, tests, documentation, and example app.
+
+## Tasks
+
+- [x] 1. Define foundational types and extend existing types
+  - [x] 1.1 Add `structuredOutput` case to `ConverseFeature` enum
+    - Add `case structuredOutput = "structured-output"` to `Sources/BedrockService/BedrockRuntimeClient/Modalities/ConverseFeature.swift`
+    - Update any model definitions that support structured output to include `.structuredOutput` in their `converseFeatures` array
+    - _Requirements: 6.1, 6.2, 6.3, 6.4_
+
+  - [x] 1.2 Create `OutputFormat` struct with initializers and validation
+    - Create `Sources/BedrockService/BedrockRuntimeClient/Converse/OutputFormat.swift`
+    - Implement `OutputFormat` struct conforming to `Codable` and `Sendable`
+    - Store `schema: JSON`, `name: String`, `description: String?`
+    - Implement `init(schema: JSON, name: String, description: String?)` with validation: name must match `[a-zA-Z0-9_-]+`, schema must not be `.null`
+    - Implement `init(schema: String, name: String, description: String?)` that parses the JSON string
+    - Throw `BedrockLibraryError.invalidName` for empty or invalid names
+    - Throw `BedrockLibraryError.invalid` for null schema
+    - Throw `BedrockLibraryError.decodingError` for invalid JSON strings
+    - Use the same name validation regex pattern as `Tool`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 7.1, 7.2, 7.3_
+
+  - [x] 1.3 Implement `OutputFormat.getSDKOutputFormat()` conversion method
+    - Add `func getSDKOutputFormat() throws -> BedrockRuntimeClientTypes.OutputFormat`
+    - Serialize schema to JSON string via `schema.toJSONString()`
+    - Construct `BedrockRuntimeClientTypes.JsonSchemaDefinition` with name, description, and schema string
+    - Wrap in `BedrockRuntimeClientTypes.OutputFormatStructure.jsonSchema(...)`
+    - Return `BedrockRuntimeClientTypes.OutputFormat(structure:type:)` with type `.jsonSchema`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_
+
+  - [x] 1.4 Add `strict` property to `Tool` struct
+    - Add `public let strict: Bool` property to `Tool` in `Sources/BedrockService/BedrockRuntimeClient/Converse/Tool.swift`
+    - Update `init(name:inputSchema:description:)` to accept `strict: Bool = false` parameter
+    - Update `init(from sdkToolSpecification:)` to read `strict` from the SDK type (default to `false` if nil)
+    - Update `getSDKToolSpecification()` to pass `strict: true` when enabled, `nil` when false
+    - Ensure backward compatibility: existing callers compile without changes
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7_
+
+- [x] 2. Integrate structured output into builder and request pipeline
+  - [x] 2.1 Extend `ConverseRequestBuilder` with `withOutputFormat` methods
+    - Add `public private(set) var outputFormat: OutputFormat?` property to `ConverseRequestBuilder`
+    - Implement `public func withOutputFormat(_ outputFormat: OutputFormat) throws -> ConverseRequestBuilder` that validates `.structuredOutput` feature support and stores the format
+    - Implement convenience `withOutputFormat(schema: JSON, name: String, description: String?)` that creates an `OutputFormat` and delegates
+    - Implement convenience `withOutputFormat(schema: String, name: String, description: String?)` that creates an `OutputFormat` and delegates
+    - Update `init(from builder:)` to copy `outputFormat` from the source builder
+    - Ensure value semantics: original builder is not mutated
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9_
+
+  - [x] 2.2 Extend `ConverseRequest` to propagate `outputFormat` to SDK input
+    - Add `let outputFormat: OutputFormat?` property to `ConverseRequest`
+    - Update `ConverseRequest` initializer to accept `outputFormat` parameter
+    - Update `getConverseInput(forRegion:)` to include `outputFormat: try outputFormat?.getSDKOutputFormat()` in the `ConverseInput`
+    - _Requirements: 5.1, 5.2_
+
+  - [x] 2.3 Extend streaming request to propagate `outputFormat`
+    - Update the streaming request construction (ConverseStreamInput) to include `outputFormat: try outputFormat?.getSDKOutputFormat()`
+    - Ensure nil propagation when outputFormat is not set
+    - _Requirements: 5.3, 5.4_
+
+  - [x] 2.4 Wire `ConverseRequestBuilder` to pass `outputFormat` through to `ConverseRequest`
+    - Update `BedrockService.converse(with builder:)` and the streaming equivalent to pass `builder.outputFormat` when constructing `ConverseRequest`
+    - Ensure the existing `converse(with model:conversation:...)` path is unaffected (no outputFormat)
+    - _Requirements: 4.9, 5.1, 5.2, 5.3, 5.4_
+
+- [x] 3. Checkpoint - Verify compilation and existing tests
+  - Ensure `swift build` succeeds and `swift test` passes with all existing tests still green. Ask the user if questions arise.
+
+- [x] 4. Unit tests for structured output
+  - [x] 4.1 Write unit tests for `OutputFormat` initialization and validation
+    - Create `Tests/Converse/OutputFormatTests.swift`
+    - Test successful creation with valid JSON and valid name
+    - Test creation with description and without description
+    - Test failure for null JSON schema
+    - Test failure for invalid JSON string
+    - Test failure for empty name
+    - Test failure for name with invalid characters (spaces, special chars)
+    - Use Swift Testing framework (`@Test`, `#expect`, `#require`)
+    - _Requirements: 10.2, 10.3_
+
+  - [x] 4.2 Write unit tests for `OutputFormat.getSDKOutputFormat()`
+    - Test that the returned SDK type has `.jsonSchema` type
+    - Test that the schema string round-trips correctly
+    - Test that name and description are set correctly
+    - Test that nil description produces nil in the SDK type
+    - _Requirements: 10.4_
+
+  - [x] 4.3 Write unit tests for `Tool` strict parameter
+    - Add tests to `Tests/Converse/ConverseToolTests.swift` or create a new file
+    - Test `Tool(name:inputSchema:description:strict: true)` stores `strict == true`
+    - Test `Tool(name:inputSchema:description:)` without strict defaults to `false`
+    - Test `getSDKToolSpecification()` returns `strict: true` when strict is true
+    - Test `getSDKToolSpecification()` returns `strict: nil` when strict is false
+    - Test backward compatibility: existing initializer compiles and works
+    - _Requirements: 10.5, 10.6, 10.7_
+
+  - [x] 4.4 Write unit tests for `ConverseRequestBuilder.withOutputFormat()`
+    - Test that `withOutputFormat` stores the format on a supported model
+    - Test that `withOutputFormat` throws `BedrockLibraryError.invalidModality` on an unsupported model
+    - Test builder immutability: original builder's `outputFormat` remains nil after calling `withOutputFormat`
+    - Test `init(from:)` preserves `outputFormat` from source builder
+    - Test that multiple `withOutputFormat` calls use the last one
+    - _Requirements: 10.8, 10.9, 10.10_
+
+  - [x] 4.5 Write unit tests for `ConverseRequest` output format propagation
+    - Test `getConverseInput()` includes `outputFormat` when set
+    - Test `getConverseInput()` has nil `outputFormat` when not set
+    - Test streaming input includes `outputFormat` when set
+    - _Requirements: 10.11_
+
+- [x] 5. Checkpoint - Ensure all tests pass
+  - Run `swift test` and ensure all new and existing tests pass. Ask the user if questions arise.
+
+- [x] 6. Property-based tests for correctness properties
+  - [x] 6.1 Write property test for backward compatibility (Property 1)
+    - **Property 1: Backward Compatibility**
+    - For any valid tool name and schema, creating a Tool without the strict parameter results in `strict == false` and `getSDKToolSpecification().strict == nil`
+    - **Validates: Requirements 3.2, 3.4, 3.5**
+
+  - [x] 6.2 Write property test for schema preservation (Property 2)
+    - **Property 2: Schema Preservation**
+    - For any valid JSON schema and valid name, `OutputFormat(schema:name:).getSDKOutputFormat()` produces a JsonSchemaDefinition whose schema string, when parsed back, is semantically equivalent to the original
+    - **Validates: Requirements 1.2, 1.3, 2.2**
+
+  - [x] 6.3 Write property test for name validation consistency (Property 3)
+    - **Property 3: Name Validation Consistency**
+    - For any string, OutputFormat name validation and Tool name validation produce the same accept/reject result
+    - **Validates: Requirements 7.1, 7.2**
+
+  - [x] 6.4 Write property test for strict tool mapping (Property 6)
+    - **Property 6: Strict Tool Mapping**
+    - For any Tool with `strict == true`, `getSDKToolSpecification().strict == true`; for `strict == false`, `.strict == nil`
+    - **Validates: Requirements 3.3, 3.4**
+
+  - [x] 6.5 Write property test for immutable builder (Property 7)
+    - **Property 7: Immutable Builder**
+    - For any builder and valid OutputFormat, calling `withOutputFormat` returns a new builder with the format set, and the original builder remains unchanged
+    - **Validates: Requirements 4.6, 4.7**
+
+- [x] 7. Documentation and example application
+  - [x] 7.1 Create DocC documentation article for structured output
+    - Create `Sources/BedrockService/Docs.docc/StructuredOutput.md`
+    - Explain JSON schema output format and strict tool use mechanisms
+    - Include code samples for OutputFormat creation (JSON, String variants)
+    - Include code samples for Tool with strict parameter
+    - Include code samples for ConverseRequestBuilder fluent API with `withOutputFormat`
+    - Document best practices for schema design (additionalProperties: false)
+    - Explain stop reason handling and when responses may not conform
+    - Include a streaming example with structured output
+    - Add See Also links to Converse.md, Tools.md, Streaming.md
+    - _Requirements: 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9_
+
+  - [x] 7.2 Create example application for structured output
+    - Create `Examples/structured-output/` directory with Package.swift, Sources/, and .gitignore
+    - Package.swift: depend on swift-bedrock-library via local path, target macOS 15, iOS 18, tvOS 18
+    - Implement `@main` struct demonstrating JSON schema output format (schema with 2+ properties, 1+ required)
+    - Demonstrate strict tool use (Tool with `strict: true`, detect ToolUseBlock in response)
+    - Verify model supports `.structuredOutput` via `hasConverseModality` before making requests
+    - Print error and exit if model doesn't support structured output
+    - Use do/catch for error handling, print results to stdout
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8_
+
+- [x] 8. Final checkpoint - Ensure all tests pass and project builds
+  - Run `swift build` and `swift test`. Verify the example compiles with `swift build` in the Examples/structured-output directory. Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The design uses Swift directly, so all implementation tasks use Swift
+- The project uses Swift Testing framework (@Test, #expect, #require) — not XCTest
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "1.2"] },
+    { "id": 1, "tasks": ["1.3", "1.4"] },
+    { "id": 2, "tasks": ["2.1"] },
+    { "id": 3, "tasks": ["2.2", "2.3"] },
+    { "id": 4, "tasks": ["2.4"] },
+    { "id": 5, "tasks": ["4.1", "4.2", "4.3"] },
+    { "id": 6, "tasks": ["4.4", "4.5"] },
+    { "id": 7, "tasks": ["6.1", "6.2", "6.3", "6.4", "6.5"] },
+    { "id": 8, "tasks": ["7.1", "7.2"] }
+  ]
+}
+```

--- a/.kiro/steering/swift.md
+++ b/.kiro/steering/swift.md
@@ -1,116 +1,71 @@
-You are a coding assistant--with access to tools--specializing 
-in analyzing codebases. Below is the content of the file the 
-user is working on. Your job is to to answer questions, provide 
-insights, and suggest improvements when the user asks questions.
+# Swift 6 Project Guidelines
 
-Do not answer with any code until you are sure the user has 
-provided all code snippets and type implementations required to 
-answer their question.
+## Language & Platform
 
-Briefly--in as little text as possible--walk through the solution 
-in prose to identify types you need that are missing from the files 
-that have been sent to you.
+- Always prefer Swift. Fall back to Objective-C, C, or C++ only when necessary.
+- Favor Apple frameworks and APIs already available on device.
+- Use official platform names: iOS, iPadOS, macOS, watchOS, visionOS.
+- Pay attention to platform clues — don't suggest iOS-only APIs for a Mac app.
 
-Whenever possible, favor Apple programming languages and 
-frameworks or APIs that are already available on Apple devices. 
-Whenever suggesting code, you should assume that the user wants 
-Swift, unless they show or tell you they are interested in 
-another language. 
- 
-Always prefer Swift, Objective-C, C, and C++ over alternatives. 
+## Swift 6 Concurrency
 
-Pay close attention to the platform that this code is for. 
-For example, if you see clues that the user is writing a Mac 
-app, avoid suggesting iOS-only APIs.
+- Prefer Swift Concurrency (async/await, actors) over Dispatch or Combine.
+- Use structured concurrency (`async let`, `withTaskGroup`) over unstructured `Task` when possible.
+- Use `Task.detached` only with a documented reason.
+- Match a `Task`'s entry isolation to its synchronous prefix — start on `@MainActor` only when the prefix truly needs it; otherwise use `Task { @concurrent in ... }` and hop back with `MainActor.run`.
+- Don't apply `@MainActor` as a blanket fix — justify that the code is truly UI-bound.
+- Prefer `actor` or `Mutex` over locks/queues for shared mutable state.
+- Prefer immutable values and explicit boundaries over `@unchecked Sendable`.
+- If recommending `@preconcurrency`, `@unchecked Sendable`, or `nonisolated(unsafe)`, require a safety invariant and a removal plan.
 
-Refer to Apple platforms with their official names, like iOS, 
-iPadOS, macOS, watchOS and visionOS. Avoid mentioning specific 
-products and instead use these platform names.
+## Before Fixing Concurrency Issues
 
-In most projects, you can also provide code examples using the new 
-Swift Testing framework that uses Swift Macros. An example of this 
-code is below:
- 
+1. Check `Package.swift` for: Swift language mode, strict concurrency level, default isolation, upcoming features.
+2. Capture the exact diagnostic and offending symbol.
+3. Determine the isolation boundary (`@MainActor`, custom actor, `nonisolated`).
+4. Optimize for the smallest safe change — don't refactor unrelated architecture.
+
+## Testing
+
+- Always use Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) over XCTest.
+- Use `swift test` to run tests.
+
 ```swift
- 
 import Testing
- 
-// Optional, you can also just say `@Suite` with no parentheses.
-@Suite("You can put a test suite name here, formatted as normal text.")
-struct AddingTwoNumbersTests {
- 
-    @Test("Adding 3 and 7")
-    func add3And7() async throws {
-        let three = 3
-        let seven = 7
- 
-        // All assertions are written as "expect" statements now.
-        #expect(three + seven == 10, "The sums should work out.")
+
+@Suite("Example")
+struct ExampleTests {
+    @Test("Adding numbers")
+    func addNumbers() async throws {
+        #expect(3 + 7 == 10)
     }
- 
+
     @Test
-    func add3And7WithOptionalUnwrapping() async throws {
-        let three: Int? = 3
-        let seven = 7
- 
-        // Similar to `XCTUnwrap`
-        let unwrappedThree = try #require(three)
- 
-        let sum = three + seven
- 
-        #expect(sum == 10)
+    func optionalUnwrap() async throws {
+        let value: Int? = 42
+        let unwrapped = try #require(value)
+        #expect(unwrapped == 42)
     }
- 
 }
 ```
 
-Always use standard Swift 6 tools by preference. For example, 
-when asked to write unit tests, always prefer the new Swift testing framework over XCTest.
-When asked to format files, use swift format instead of swift-format.
+## Tooling
 
-In general, prefer the use of Swift Concurrency (async/await, 
-actors, etc.) over tools like Dispatch or Combine, but if the 
-user's code or words show you they may prefer something else, 
-you should be flexible to this preference.
+- Use `swift format` (not `swift-format`) for formatting.
+- Use `swift build` and `swift test` for building and testing.
+- Run SPM commands (`swift build`, `swift test`, `swift package`) sequentially — never in parallel. SPM applies a directory-level lock, so concurrent invocations will fail.
 
-Sometimes, the user may provide specific code snippets for your 
-use. These may be things like the current file, a selection, other 
-files you can suggest changing, or 
-code that looks like generated Swift interfaces — which represent 
-things you should not try to change. 
- 
-However, this query will start without any additional context.
+## API Design (Swift conventions)
 
-When it makes sense, you should propose changes to existing code. 
-Whenever you are proposing changes to an existing file, 
-it is imperative that you repeat the entire file, without ever 
-eliding pieces, even if they will be kept identical to how they are 
-currently. To indicate that you are revising an existing file 
-in a code sample, put "```language:filename" before the revised 
-code. It is critical that you only propose replacing files that 
-have been sent to you. For example, if you are revising 
-FooBar.swift, you would say:
- 
-```swift:FooBar.swift
-// the entire code of the file with your changes goes here.
-// Do not skip over anything.
-```
+- Clarity at the point of use is the top priority.
+- Name methods by their side-effects: noun phrases for non-mutating, imperative verbs for mutating.
+- Use `lowerCamelCase` for functions/properties, `UpperCamelCase` for types/protocols.
+- Omit needless words; name parameters by role, not type.
+- Begin factory methods with `make`.
+- Boolean properties read as assertions: `isEmpty`, `isValid`.
 
-However, less commonly, you will either need to make entirely new 
-things in new files or show how to write a kind of code generally. 
-When you are in this rarer circumstance, you can just show the 
-user a code snippet, with normal markdown:
-```swift
-// Swift code here
-```
+## Code Proposals
 
-
-
-## Pre-commit formatting
-
-Always run `swift format` on any modified Swift files before committing. This ensures consistent code style across the project.
-
-When preparing a commit:
-1. Identify all `.swift` files that have been modified.
-2. Run `swift format -i <file>` on each modified file.
-3. Then stage and commit the changes.
+- When proposing changes to an existing file, reproduce the entire file (no elisions).
+- Mark revised files as ` ```swift:Filename.swift `.
+- For new files or general examples, use plain ` ```swift ` blocks.

--- a/.licenseignore
+++ b/.licenseignore
@@ -38,6 +38,7 @@ Package.resolved
 **/*.code-snippets
 .DS_Store
 .licenseignore
+**/*.kiro
 **/*.entitlements
 .nojekyll
 docs/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# Swift 6 Project Guidelines
+
+## Language & Platform
+
+- Always prefer Swift. Fall back to Objective-C, C, or C++ only when necessary.
+- Favor Apple frameworks and APIs already available on device.
+- Use official platform names: iOS, iPadOS, macOS, watchOS, visionOS.
+- Pay attention to platform clues — don't suggest iOS-only APIs for a Mac app.
+
+## Swift 6 Concurrency
+
+- Prefer Swift Concurrency (async/await, actors) over Dispatch or Combine.
+- Use structured concurrency (`async let`, `withTaskGroup`) over unstructured `Task` when possible.
+- Use `Task.detached` only with a documented reason.
+- Match a `Task`'s entry isolation to its synchronous prefix — start on `@MainActor` only when the prefix truly needs it; otherwise use `Task { @concurrent in ... }` and hop back with `MainActor.run`.
+- Don't apply `@MainActor` as a blanket fix — justify that the code is truly UI-bound.
+- Prefer `actor` or `Mutex` over locks/queues for shared mutable state.
+- Prefer immutable values and explicit boundaries over `@unchecked Sendable`.
+- If recommending `@preconcurrency`, `@unchecked Sendable`, or `nonisolated(unsafe)`, require a safety invariant and a removal plan.
+
+## Before Fixing Concurrency Issues
+
+1. Check `Package.swift` for: Swift language mode, strict concurrency level, default isolation, upcoming features.
+2. Capture the exact diagnostic and offending symbol.
+3. Determine the isolation boundary (`@MainActor`, custom actor, `nonisolated`).
+4. Optimize for the smallest safe change — don't refactor unrelated architecture.
+
+## Testing
+
+- Always use Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) over XCTest.
+- Use `swift test` to run tests.
+
+```swift
+import Testing
+
+@Suite("Example")
+struct ExampleTests {
+    @Test("Adding numbers")
+    func addNumbers() async throws {
+        #expect(3 + 7 == 10)
+    }
+
+    @Test
+    func optionalUnwrap() async throws {
+        let value: Int? = 42
+        let unwrapped = try #require(value)
+        #expect(unwrapped == 42)
+    }
+}
+```
+
+## Tooling
+
+- Use `swift format` (not `swift-format`) for formatting.
+- Use `swift build` and `swift test` for building and testing.
+- Run SPM commands (`swift build`, `swift test`, `swift package`) sequentially — never in parallel. SPM applies a directory-level lock, so concurrent invocations will timeout.
+
+## API Design (Swift conventions)
+
+- Clarity at the point of use is the top priority.
+- Name methods by their side-effects: noun phrases for non-mutating, imperative verbs for mutating.
+- Use `lowerCamelCase` for functions/properties, `UpperCamelCase` for types/protocols.
+- Omit needless words; name parameters by role, not type.
+- Begin factory methods with `make`.
+- Boolean properties read as assertions: `isEmpty`, `isValid`.
+
+## Code Proposals
+
+- When proposing changes to an existing file, reproduce the entire file (no elisions).
+- Mark revised files as ` ```swift:Filename.swift `.
+- For new files or general examples, use plain ` ```swift ` blocks.

--- a/Examples/structured-output/.gitignore
+++ b/Examples/structured-output/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Examples/structured-output/Package.swift
+++ b/Examples/structured-output/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "StructuredOutput",
+    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18)],
+    products: [
+        .executable(name: "StructuredOutput", targets: ["StructuredOutput"])
+    ],
+    dependencies: [
+        // for production use, uncomment the following line
+        // .package(url: "https://github.com/build-on-aws/swift-bedrock-library.git", branch: "main"),
+
+        // for local development, use the following line
+        .package(name: "swift-bedrock-library", path: "../.."),
+
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "StructuredOutput",
+            dependencies: [
+                .product(name: "BedrockService", package: "swift-bedrock-library"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        )
+    ]
+)

--- a/Examples/structured-output/Sources/StructuredOutput.swift
+++ b/Examples/structured-output/Sources/StructuredOutput.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BedrockService
+import Logging
+
+@main
+struct Main {
+    static func main() async throws {
+        do {
+            try await Main.structuredOutput()
+        } catch {
+            print("Error:\n\(error)")
+        }
+    }
+
+    static func structuredOutput() async throws {
+        var logger = Logger(label: "StructuredOutput")
+        logger.logLevel = .info
+
+        let bedrock = try await BedrockService(
+            region: .useast1,
+            logger: logger
+        )
+
+        // Select a model that supports structured output
+        let model: BedrockModel = .claude_sonnet_v4_5
+
+        // Verify the model supports structured output before making requests
+        guard model.hasConverseModality(.structuredOutput) else {
+            print("Error: \(model.name) does not support structured output.")
+            return
+        }
+
+        // --- Part 1: JSON Schema Output Format ---
+        print("=== JSON Schema Output Format ===\n")
+        try await demonstrateJsonSchemaOutput(bedrock: bedrock, model: model)
+
+        print("\n")
+
+        // --- Part 2: Strict Tool Use ---
+        print("=== Strict Tool Use ===\n")
+        try await demonstrateStrictToolUse(bedrock: bedrock, model: model)
+    }
+
+    /// Demonstrates JSON schema output format with a schema containing 2+ properties and 1+ required field.
+    static func demonstrateJsonSchemaOutput(bedrock: BedrockService, model: BedrockModel) async throws {
+        // Define a JSON schema with multiple properties and required fields
+        let schema = """
+        {
+            "type": "object",
+            "properties": {
+                "title": { "type": "string", "description": "The book title" },
+                "author": { "type": "string", "description": "The author name" },
+                "year": { "type": "integer", "description": "Publication year" },
+                "genre": { "type": "string", "description": "The book genre" }
+            },
+            "required": ["title", "author", "year"],
+            "additionalProperties": false
+        }
+        """
+
+        let builder = try ConverseRequestBuilder(with: model)
+            .withPrompt("Give me information about the novel '1984' by George Orwell. Return the data as JSON.")
+            .withOutputFormat(schema: schema, name: "book_info", description: "Information about a book")
+
+        let reply = try await bedrock.converse(with: builder)
+        let jsonText = try reply.getTextReply()
+        print("Structured JSON response:")
+        print(jsonText)
+    }
+
+    /// Demonstrates strict tool use with a Tool that has strict set to true.
+    static func demonstrateStrictToolUse(bedrock: BedrockService, model: BedrockModel) async throws {
+        // Define a tool with strict: true for validated input parameters
+        let tool = try Tool(
+            name: "get_weather",
+            inputSchema: try JSON(from: """
+            {
+                "type": "object",
+                "properties": {
+                    "location": { "type": "string", "description": "City name" },
+                    "unit": { "type": "string", "enum": ["celsius", "fahrenheit"], "description": "Temperature unit" }
+                },
+                "required": ["location", "unit"],
+                "additionalProperties": false
+            }
+            """),
+            description: "Get the current weather for a location",
+            strict: true
+        )
+
+        let builder = try ConverseRequestBuilder(with: model)
+            .withPrompt("What is the weather in Paris in celsius?")
+            .withTool(tool)
+
+        let reply = try await bedrock.converse(with: builder)
+
+        // Detect the ToolUseBlock in the response
+        let toolUseBlock = try reply.getToolUse()
+        print("Tool called: \(toolUseBlock.name)")
+        print("Tool input parameters: \(toolUseBlock.input)")
+    }
+}

--- a/Examples/structured-output/Sources/StructuredOutput.swift
+++ b/Examples/structured-output/Sources/StructuredOutput.swift
@@ -59,18 +59,18 @@ struct Main {
     static func demonstrateJsonSchemaOutput(bedrock: BedrockService, model: BedrockModel) async throws {
         // Define a JSON schema with multiple properties and required fields
         let schema = """
-        {
-            "type": "object",
-            "properties": {
-                "title": { "type": "string", "description": "The book title" },
-                "author": { "type": "string", "description": "The author name" },
-                "year": { "type": "integer", "description": "Publication year" },
-                "genre": { "type": "string", "description": "The book genre" }
-            },
-            "required": ["title", "author", "year"],
-            "additionalProperties": false
-        }
-        """
+            {
+                "type": "object",
+                "properties": {
+                    "title": { "type": "string", "description": "The book title" },
+                    "author": { "type": "string", "description": "The author name" },
+                    "year": { "type": "integer", "description": "Publication year" },
+                    "genre": { "type": "string", "description": "The book genre" }
+                },
+                "required": ["title", "author", "year"],
+                "additionalProperties": false
+            }
+            """
 
         let builder = try ConverseRequestBuilder(with: model)
             .withPrompt("Give me information about the novel '1984' by George Orwell. Return the data as JSON.")
@@ -87,17 +87,19 @@ struct Main {
         // Define a tool with strict: true for validated input parameters
         let tool = try Tool(
             name: "get_weather",
-            inputSchema: try JSON(from: """
-            {
-                "type": "object",
-                "properties": {
-                    "location": { "type": "string", "description": "City name" },
-                    "unit": { "type": "string", "enum": ["celsius", "fahrenheit"], "description": "Temperature unit" }
-                },
-                "required": ["location", "unit"],
-                "additionalProperties": false
-            }
-            """),
+            inputSchema: try JSON(
+                from: """
+                    {
+                        "type": "object",
+                        "properties": {
+                            "location": { "type": "string", "description": "City name" },
+                            "unit": { "type": "string", "enum": ["celsius", "fahrenheit"], "description": "Temperature unit" }
+                        },
+                        "required": ["location", "unit"],
+                        "additionalProperties": false
+                    }
+                    """
+            ),
             description: "Get the current weather for a location",
             strict: true
         )

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/BedrockService+Converse.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/BedrockService+Converse.swift
@@ -176,9 +176,19 @@ extension BedrockService {
             var history = builder.history
             let userMessage = try builder.getUserMessage()
             history.append(userMessage)
-            let assistantMessage: Message = try await converse(
-                with: builder.model,
-                conversation: history,
+
+            let modality = try builder.model.getConverseModality()
+            let parameters = modality.getConverseParameters()
+            try parameters.validate(
+                maxTokens: builder.maxTokens,
+                temperature: builder.temperature,
+                topP: builder.topP,
+                stopSequences: builder.stopSequences
+            )
+
+            let converseRequest = ConverseRequest(
+                model: builder.model,
+                messages: history,
                 maxTokens: builder.maxTokens,
                 temperature: builder.temperature,
                 topP: builder.topP,
@@ -186,8 +196,14 @@ extension BedrockService {
                 systemPrompts: builder.systemPrompts,
                 tools: builder.tools,
                 maxReasoningTokens: builder.maxReasoningTokens,
-                serviceTier: builder.serviceTier
+                serviceTier: builder.serviceTier,
+                outputFormat: builder.outputFormat
             )
+
+            let input = try converseRequest.getConverseInput(forRegion: self.region)
+            let response: ConverseOutput = try await self.bedrockRuntimeClient.converse(input: input)
+
+            let assistantMessage = try Message(response)
             history.append(assistantMessage)
             logger.trace(
                 "Received message",
@@ -195,8 +211,7 @@ extension BedrockService {
             )
             return try ConverseReply(history)
         } catch {
-            logger.trace("Error while conversing", metadata: ["error": "\(error)"])
-            throw error
+            try handleCommonError(error, context: "invoking converse")
         }
     }
 }

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/ConverseRequest.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/ConverseRequest.swift
@@ -30,6 +30,7 @@ public struct ConverseRequest {
     let systemPrompts: [String]?
     let maxReasoningTokens: Int?
     let serviceTier: ServiceTier
+    let outputFormat: OutputFormat?
 
     @available(
         *,
@@ -72,7 +73,8 @@ public struct ConverseRequest {
         systemPrompts: [String]?,
         tools: [Tool]?,
         maxReasoningTokens: Int?,
-        serviceTier: ServiceTier
+        serviceTier: ServiceTier,
+        outputFormat: OutputFormat? = nil
     ) {
         self.messages = messages
         self.model = model
@@ -90,14 +92,25 @@ public struct ConverseRequest {
             self.toolConfig = nil
         }
         self.serviceTier = serviceTier
+        self.outputFormat = outputFormat
     }
 
     func getConverseInput(forRegion region: Region) throws -> ConverseInput {
-        ConverseInput(
+        let sdkOutputConfig: BedrockRuntimeClientTypes.OutputConfig?
+        if let outputFormat {
+            sdkOutputConfig = BedrockRuntimeClientTypes.OutputConfig(
+                textFormat: try outputFormat.getSDKOutputFormat()
+            )
+        } else {
+            sdkOutputConfig = nil
+        }
+
+        return ConverseInput(
             additionalModelRequestFields: try getAdditionalModelRequestFields(),
             inferenceConfig: inferenceConfig?.getSDKInferenceConfig(),
             messages: try getSDKMessages(),
             modelId: model.getModelIdWithCrossRegionInferencePrefix(region: region),
+            outputConfig: sdkOutputConfig,
             serviceTier: BedrockRuntimeClientTypes.ServiceTier(type: .init(rawValue: serviceTier.rawValue)),
             system: getSDKSystemPrompts(),
             toolConfig: try toolConfig?.getSDKToolConfig()

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/ConverseRequestBuilder.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/ConverseRequestBuilder.swift
@@ -767,7 +767,11 @@ public struct ConverseRequestBuilder: Sendable {
     /// - Throws: `BedrockLibraryError.invalidModality` if the model doesn't support structured output.
     /// - Throws: `BedrockLibraryError.invalidName` if name is empty or contains invalid characters.
     /// - Throws: `BedrockLibraryError.invalid` if schema is null.
-    public func withOutputFormat(schema: JSON, name: String, description: String? = nil) throws
+    public func withOutputFormat(
+        schema: JSON,
+        name: String,
+        description: String? = nil
+    ) throws
         -> ConverseRequestBuilder
     {
         let format = try OutputFormat(schema: schema, name: name, description: description)
@@ -786,7 +790,11 @@ public struct ConverseRequestBuilder: Sendable {
     /// - Throws: `BedrockLibraryError.invalidModality` if the model doesn't support structured output.
     /// - Throws: `BedrockLibraryError.decodingError` if the schema string is not valid JSON.
     /// - Throws: `BedrockLibraryError.invalidName` if name is empty or contains invalid characters.
-    public func withOutputFormat(schema: String, name: String, description: String? = nil) throws
+    public func withOutputFormat(
+        schema: String,
+        name: String,
+        description: String? = nil
+    ) throws
         -> ConverseRequestBuilder
     {
         let format = try OutputFormat(schema: schema, name: name, description: description)

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/ConverseRequestBuilder.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/ConverseRequestBuilder.swift
@@ -70,6 +70,9 @@ public struct ConverseRequestBuilder: Sendable {
     /// The service tier for the inference request.
     public private(set) var serviceTier: ServiceTier = .default
 
+    /// The structured output format configuration, if any.
+    public private(set) var outputFormat: OutputFormat?
+
     // MARK - Initializers
 
     /// Creates a new builder for the specified Bedrock model.
@@ -100,7 +103,7 @@ public struct ConverseRequestBuilder: Sendable {
     /// - Parameter builder: The builder to copy configuration from.
     /// - Throws: `BedrockLibraryError` if validation fails during configuration copy.
     public init(from builder: ConverseRequestBuilder) throws {
-        self = try ConverseRequestBuilder(with: builder.model)
+        var copy = try ConverseRequestBuilder(with: builder.model)
             .withHistory(builder.history)
             .withTemperature(builder.temperature)
             .withTopP(builder.topP)
@@ -110,6 +113,8 @@ public struct ConverseRequestBuilder: Sendable {
             .withTools(builder.tools)
             .withReasoning(enabled: builder.enableReasoning, maxReasoningTokens: builder.maxReasoningTokens)
             .withServiceTier(builder.serviceTier)
+        copy.outputFormat = builder.outputFormat
+        self = copy
     }
 
     /// Creates a new builder from an existing builder with updated conversation history from a reply.
@@ -731,6 +736,61 @@ public struct ConverseRequestBuilder: Sendable {
         var copy = self
         copy.serviceTier = serviceTier
         return copy
+    }
+
+    // MARK - builder methods - structured output
+
+    /// Sets the structured output format for the request.
+    ///
+    /// Structured output constrains the model's response to conform to the specified JSON schema.
+    /// The model must support the `.structuredOutput` converse feature.
+    ///
+    /// - Parameter outputFormat: The output format configuration containing the JSON schema.
+    /// - Returns: A new builder with the output format set.
+    /// - Throws: `BedrockLibraryError.invalidModality` if the model doesn't support structured output.
+    public func withOutputFormat(_ outputFormat: OutputFormat) throws -> ConverseRequestBuilder {
+        try validateFeature(.structuredOutput)
+        var copy = self
+        copy.outputFormat = outputFormat
+        return copy
+    }
+
+    /// Sets the structured output format from a JSON schema value.
+    ///
+    /// Convenience method that creates an `OutputFormat` and configures the builder.
+    ///
+    /// - Parameters:
+    ///   - schema: A valid JSON value representing the schema.
+    ///   - name: A name for the schema matching `[a-zA-Z0-9_-]+`.
+    ///   - description: An optional description of what the schema represents.
+    /// - Returns: A new builder with the output format set.
+    /// - Throws: `BedrockLibraryError.invalidModality` if the model doesn't support structured output.
+    /// - Throws: `BedrockLibraryError.invalidName` if name is empty or contains invalid characters.
+    /// - Throws: `BedrockLibraryError.invalid` if schema is null.
+    public func withOutputFormat(schema: JSON, name: String, description: String? = nil) throws
+        -> ConverseRequestBuilder
+    {
+        let format = try OutputFormat(schema: schema, name: name, description: description)
+        return try self.withOutputFormat(format)
+    }
+
+    /// Sets the structured output format from a JSON schema string.
+    ///
+    /// Convenience method that parses the JSON string, creates an `OutputFormat`, and configures the builder.
+    ///
+    /// - Parameters:
+    ///   - schema: A syntactically valid JSON string representing the schema.
+    ///   - name: A name for the schema matching `[a-zA-Z0-9_-]+`.
+    ///   - description: An optional description of what the schema represents.
+    /// - Returns: A new builder with the output format set.
+    /// - Throws: `BedrockLibraryError.invalidModality` if the model doesn't support structured output.
+    /// - Throws: `BedrockLibraryError.decodingError` if the schema string is not valid JSON.
+    /// - Throws: `BedrockLibraryError.invalidName` if name is empty or contains invalid characters.
+    public func withOutputFormat(schema: String, name: String, description: String? = nil) throws
+        -> ConverseRequestBuilder
+    {
+        let format = try OutputFormat(schema: schema, name: name, description: description)
+        return try self.withOutputFormat(format)
     }
 
     // MARK - public methods

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/OutputFormat.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/OutputFormat.swift
@@ -43,7 +43,7 @@ public struct OutputFormat: Codable, Sendable {
         guard !name.isEmpty else {
             throw BedrockLibraryError.invalidName("OutputFormat name is not allowed to be empty")
         }
-        guard name.contains(/[a-zA-Z0-9_-]+/) else {
+        guard name.wholeMatch(of: /[a-zA-Z0-9_-]+/) != nil else {
             throw BedrockLibraryError.invalidName(
                 "OutputFormat name must consist of only lowercase letter, uppercase letters, digits, underscores and hyphens"
             )

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/OutputFormat.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/OutputFormat.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@preconcurrency import AWSBedrockRuntime
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Represents the structured output configuration for the Converse API.
+/// Encapsulates a JSON schema definition that constrains model output.
+public struct OutputFormat: Codable, Sendable {
+    /// The JSON schema that constrains the model's output
+    public let schema: JSON
+    /// A name identifying this schema (used for caching)
+    public let name: String
+    /// An optional description of what the schema represents
+    public let description: String?
+
+    /// Creates an OutputFormat with a JSON schema value.
+    ///
+    /// - Parameters:
+    ///   - schema: A valid JSON value representing the schema. Must not be `.null`.
+    ///   - name: A name for the schema matching `[a-zA-Z0-9_-]+`.
+    ///   - description: An optional description of what the schema represents.
+    /// - Throws: `BedrockLibraryError.invalidName` if name is empty or contains invalid characters.
+    /// - Throws: `BedrockLibraryError.invalid` if schema is null.
+    public init(schema: JSON, name: String, description: String? = nil) throws {
+        guard !name.isEmpty else {
+            throw BedrockLibraryError.invalidName("OutputFormat name is not allowed to be empty")
+        }
+        guard name.contains(/[a-zA-Z0-9_-]+/) else {
+            throw BedrockLibraryError.invalidName(
+                "OutputFormat name must consist of only lowercase letter, uppercase letters, digits, underscores and hyphens"
+            )
+        }
+        if case .null = schema.value {
+            throw BedrockLibraryError.invalid("OutputFormat schema must not be null")
+        }
+        self.schema = schema
+        self.name = name
+        self.description = description
+    }
+
+    /// Creates an OutputFormat by parsing a JSON string.
+    ///
+    /// - Parameters:
+    ///   - schema: A syntactically valid JSON string representing the schema.
+    ///   - name: A name for the schema matching `[a-zA-Z0-9_-]+`.
+    ///   - description: An optional description of what the schema represents.
+    /// - Throws: `BedrockLibraryError.decodingError` if the schema string is not valid JSON.
+    /// - Throws: `BedrockLibraryError.invalidName` if name is empty or contains invalid characters.
+    /// - Throws: `BedrockLibraryError.invalid` if the parsed schema is null.
+    public init(schema: String, name: String, description: String? = nil) throws {
+        let parsedSchema: JSON
+        do {
+            parsedSchema = try JSON(from: schema)
+        } catch let error as BedrockLibraryError {
+            throw error
+        } catch {
+            throw BedrockLibraryError.decodingError("Failed to decode JSON: \(error)")
+        }
+        try self.init(schema: parsedSchema, name: name, description: description)
+    }
+
+    /// Converts this OutputFormat to the SDK's `BedrockRuntimeClientTypes.OutputFormat` type.
+    ///
+    /// - Returns: A `BedrockRuntimeClientTypes.OutputFormat` ready for use in a Converse API call.
+    /// - Throws: `BedrockLibraryError.encodingError` if the schema cannot be serialized to a JSON string.
+    func getSDKOutputFormat() throws -> BedrockRuntimeClientTypes.OutputFormat {
+        let encoder = JSONEncoder()
+        guard let schemaData = try? encoder.encode(schema),
+            let schemaString = String(data: schemaData, encoding: .utf8)
+        else {
+            throw BedrockLibraryError.encodingError(
+                "Could not serialize OutputFormat schema to JSON string"
+            )
+        }
+
+        let jsonSchemaDefinition = BedrockRuntimeClientTypes.JsonSchemaDefinition(
+            description: self.description,
+            name: self.name,
+            schema: schemaString
+        )
+
+        return BedrockRuntimeClientTypes.OutputFormat(
+            structure: .jsonschema(jsonSchemaDefinition),
+            type: .jsonSchema
+        )
+    }
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/Streaming/BedrockService+ConverseStreaming.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/Streaming/BedrockService+ConverseStreaming.swift
@@ -216,9 +216,26 @@ extension BedrockService {
             var history = builder.history
             let userMessage = try builder.getUserMessage()
             history.append(userMessage)
-            let streamingResponse = try await converseStream(
-                with: builder.model,
-                conversation: history,
+
+            guard builder.model.hasConverseStreamingModality() else {
+                throw BedrockLibraryError.invalidModality(
+                    builder.model,
+                    try builder.model.getConverseModality(),
+                    "This model does not support converse streaming."
+                )
+            }
+            let modality = try builder.model.getConverseModality()
+            let parameters = modality.getConverseParameters()
+            try parameters.validate(
+                maxTokens: builder.maxTokens,
+                temperature: builder.temperature,
+                topP: builder.topP,
+                stopSequences: builder.stopSequences
+            )
+
+            let converseRequest = ConverseStreamingRequest(
+                model: builder.model,
+                messages: history,
                 maxTokens: builder.maxTokens,
                 temperature: builder.temperature,
                 topP: builder.topP,
@@ -226,12 +243,23 @@ extension BedrockService {
                 systemPrompts: builder.systemPrompts,
                 tools: builder.tools,
                 maxReasoningTokens: builder.maxReasoningTokens,
-                serviceTier: builder.serviceTier
+                serviceTier: builder.serviceTier,
+                outputFormat: builder.outputFormat
             )
-            return streamingResponse
+
+            let input = try converseRequest.getConverseStreamingInput(forRegion: self.region)
+            let response: ConverseStreamOutput = try await self.bedrockRuntimeClient.converseStream(input: input)
+
+            guard let sdkStream = response.stream else {
+                throw BedrockLibraryError.invalidSDKResponse(
+                    "The response stream is missing. This error should never happen."
+                )
+            }
+
+            let reply = try ConverseReplyStream(sdkStream, logger: logger)
+            return reply
         } catch {
-            logger.trace("Error while conversing", metadata: ["error": "\(error)"])
-            throw error
+            try handleCommonError(error, context: "invoking converse stream")
         }
     }
 }

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/Streaming/ConverseRequestStreaming.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/Streaming/ConverseRequestStreaming.swift
@@ -18,11 +18,21 @@
 public typealias ConverseStreamingRequest = ConverseRequest
 extension ConverseStreamingRequest {
     func getConverseStreamingInput(forRegion region: Region) throws -> ConverseStreamInput {
-        ConverseStreamInput(
+        let sdkOutputConfig: BedrockRuntimeClientTypes.OutputConfig?
+        if let outputFormat {
+            sdkOutputConfig = BedrockRuntimeClientTypes.OutputConfig(
+                textFormat: try outputFormat.getSDKOutputFormat()
+            )
+        } else {
+            sdkOutputConfig = nil
+        }
+
+        return ConverseStreamInput(
             additionalModelRequestFields: try getAdditionalModelRequestFields(),
             inferenceConfig: inferenceConfig?.getSDKInferenceConfig(),
             messages: try getSDKMessages(),
             modelId: model.getModelIdWithCrossRegionInferencePrefix(region: region),
+            outputConfig: sdkOutputConfig,
             serviceTier: BedrockRuntimeClientTypes.ServiceTier(type: .init(rawValue: serviceTier.rawValue)),
             system: getSDKSystemPrompts(),
             toolConfig: try toolConfig?.getSDKToolConfig()

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/Tool.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/Tool.swift
@@ -32,7 +32,7 @@ public struct Tool: Codable, CustomStringConvertible, Sendable {
         guard !name.isEmpty else {
             throw BedrockLibraryError.invalidName("Tool name is not allowed to be empty")
         }
-        guard name.contains(/[a-zA-Z0-9_-]+/) else {
+        guard name.wholeMatch(of: /[a-zA-Z0-9_-]+/) != nil else {
             throw BedrockLibraryError.invalidName(
                 "Tool name must consist of only lowercase letter, uppercase letters, digits, underscores and hyphens"
             )

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/Tool.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/Tool.swift
@@ -26,8 +26,9 @@ public struct Tool: Codable, CustomStringConvertible, Sendable {
     public let name: String
     public let inputSchema: JSON
     public let toolDescription: String?
+    public let strict: Bool
 
-    public init(name: String, inputSchema: JSON, description: String? = nil) throws {
+    public init(name: String, inputSchema: JSON, description: String? = nil, strict: Bool = false) throws {
         guard !name.isEmpty else {
             throw BedrockLibraryError.invalidName("Tool name is not allowed to be empty")
         }
@@ -39,6 +40,7 @@ public struct Tool: Codable, CustomStringConvertible, Sendable {
         self.name = name
         self.inputSchema = inputSchema
         self.toolDescription = description
+        self.strict = strict
     }
 
     public init(from sdkToolSpecification: BedrockRuntimeClientTypes.ToolSpecification) throws {
@@ -61,15 +63,17 @@ public struct Tool: Codable, CustomStringConvertible, Sendable {
         self = try Tool(
             name: name,
             inputSchema: inputSchema,
-            description: sdkToolSpecification.description
+            description: sdkToolSpecification.description,
+            strict: sdkToolSpecification.strict ?? false
         )
     }
 
     public func getSDKToolSpecification() throws -> BedrockRuntimeClientTypes.ToolSpecification {
         BedrockRuntimeClientTypes.ToolSpecification(
-            description: description,
+            description: toolDescription,
             inputSchema: .json(try inputSchema.toDocument()),
-            name: name
+            name: name,
+            strict: strict ? true : nil
         )
     }
 

--- a/Sources/BedrockService/BedrockRuntimeClient/Modalities/ConverseFeature.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Modalities/ConverseFeature.swift
@@ -27,4 +27,5 @@ public enum ConverseFeature: String, Codable, Sendable {
     case toolUse = "tool-use"
     case systemPrompts = "system-prompts"
     case reasoning = "reasoning"
+    case structuredOutput = "structured-output"
 }

--- a/Sources/BedrockService/Docs.docc/StructuredOutput.md
+++ b/Sources/BedrockService/Docs.docc/StructuredOutput.md
@@ -1,0 +1,257 @@
+# Structured Output
+
+Constrain model responses to conform to a JSON schema
+
+## Overview
+
+Structured output uses constrained decoding to guarantee that model responses conform to a specified JSON schema, producing reliable machine-readable output. This is useful when you need to parse model responses programmatically — for example, extracting structured data, generating API payloads, or populating data models.
+
+The library provides two mechanisms for structured output:
+
+1. **JSON schema output format** — Forces the model to produce JSON conforming to a user-defined schema via the `withOutputFormat` builder method.
+2. **Strict tool use** — Validates tool input parameters against their schema by setting `strict: true` on tool definitions, ensuring tool calls always produce valid inputs.
+
+Both mechanisms integrate into the existing `ConverseRequestBuilder` fluent API pattern.
+
+## JSON Schema Output Format
+
+Define a JSON schema and use `withOutputFormat` to constrain the model's response:
+
+```swift
+let model: BedrockModel = .claude_sonnet_v4
+
+guard model.hasConverseModality(.structuredOutput) else {
+    throw MyError.incorrectModality("\(model.name) does not support structured output")
+}
+
+let schema = try JSON(from: """
+{
+    "type": "object",
+    "properties": {
+        "name": { "type": "string" },
+        "age": { "type": "integer" },
+        "email": { "type": "string", "format": "email" }
+    },
+    "required": ["name", "age", "email"],
+    "additionalProperties": false
+}
+""")
+
+let builder = try ConverseRequestBuilder(with: model)
+    .withPrompt("Extract the person's info from: John Doe, 30 years old, john@example.com")
+    .withOutputFormat(schema: schema, name: "person_info", description: "Person information")
+
+let reply = try await bedrock.converse(with: builder)
+let jsonText = try reply.getTextReply()
+// jsonText is guaranteed valid JSON matching the schema when stopReason is .endTurn
+```
+
+## Creating an OutputFormat
+
+You can create an `OutputFormat` in several ways:
+
+### From a JSON Value
+
+```swift
+let schema = JSON([
+    "type": "object",
+    "properties": [
+        "title": ["type": "string"],
+        "rating": ["type": "integer"]
+    ],
+    "required": ["title", "rating"],
+    "additionalProperties": false
+])
+
+let outputFormat = try OutputFormat(schema: schema, name: "movie_review")
+```
+
+### From a JSON String
+
+```swift
+let outputFormat = try OutputFormat(
+    schema: """
+    {
+        "type": "object",
+        "properties": {
+            "summary": { "type": "string" },
+            "sentiment": { "type": "string", "enum": ["positive", "negative", "neutral"] }
+        },
+        "required": ["summary", "sentiment"],
+        "additionalProperties": false
+    }
+    """,
+    name: "text_analysis",
+    description: "Structured text analysis result"
+)
+```
+
+### Using OutputFormat Directly
+
+```swift
+let outputFormat = try OutputFormat(
+    schema: schema,
+    name: "extraction_result",
+    description: "Structured extraction result"
+)
+
+let builder = try ConverseRequestBuilder(with: model)
+    .withPrompt("Analyze this text...")
+    .withOutputFormat(outputFormat)
+```
+
+## Strict Tool Use
+
+Mark a tool as strict to guarantee that the model's tool input parameters conform to the tool's input schema:
+
+```swift
+let tool = try Tool(
+    name: "get_weather",
+    inputSchema: try JSON(from: """
+    {
+        "type": "object",
+        "properties": {
+            "location": { "type": "string", "description": "City name" },
+            "unit": { "type": "string", "enum": ["celsius", "fahrenheit"] }
+        },
+        "required": ["location", "unit"],
+        "additionalProperties": false
+    }
+    """),
+    description: "Get weather for a location",
+    strict: true
+)
+
+let builder = try ConverseRequestBuilder(with: model)
+    .withPrompt("What's the weather in Paris?")
+    .withTool(tool)
+
+let reply = try await bedrock.converse(with: builder)
+let toolUse = try reply.getToolUse()
+// toolUse.input is guaranteed to match the schema — both "location" and "unit" are present
+let location: String? = toolUse.input["location"]
+let unit: String? = toolUse.input["unit"]
+```
+
+When `strict` is omitted or set to `false`, the tool behaves as before — the model may produce inputs that don't fully conform to the schema.
+
+## Streaming with Structured Output
+
+Structured output works with streaming. The model streams partial JSON tokens, and the complete response conforms to the schema:
+
+```swift
+let bookListSchema = try JSON(from: """
+{
+    "type": "object",
+    "properties": {
+        "books": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": { "type": "string" },
+                    "author": { "type": "string" },
+                    "year": { "type": "integer" }
+                },
+                "required": ["title", "author", "year"],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": ["books"],
+    "additionalProperties": false
+}
+""")
+
+let builder = try ConverseRequestBuilder(with: model)
+    .withPrompt("List 3 classic science fiction books")
+    .withOutputFormat(schema: bookListSchema, name: "book_list")
+
+let stream = try await bedrock.converseStream(with: builder)
+
+for try await element in stream.stream {
+    switch element {
+    case .text(_, let delta):
+        print(delta, terminator: "")  // Partial JSON streamed incrementally
+    case .messageComplete(let message):
+        // Full message available — text is valid JSON when stopReason is .endTurn
+        if message.stopReason == .endTurn {
+            print("\n\nResponse conforms to schema.")
+        }
+    default:
+        break
+    }
+}
+```
+
+## Stop Reason Handling
+
+Structured output guarantees schema conformance only when the model finishes normally. Check the `stopReason` to determine whether the response is safe to parse:
+
+```swift
+let reply = try await bedrock.converse(with: builder)
+let lastMessage = reply.getLastMessage()
+
+switch lastMessage.stopReason {
+case .endTurn:
+    // Response conforms to the schema — safe to parse as JSON
+    let json = try reply.getTextReply()
+    print("Valid JSON: \(json)")
+
+case .maxTokens:
+    // Response was truncated — may be incomplete or invalid JSON
+    let partial = try reply.getTextReply()
+    print("Warning: response truncated, may not be valid JSON")
+
+case .contentFiltered:
+    // Content filter intervened — response may not conform
+    print("Warning: content was filtered")
+
+case .guardrailIntervened:
+    // Guardrail intervened — response may not conform
+    print("Warning: guardrail intervened")
+
+default:
+    break
+}
+```
+
+To avoid truncation, ensure `maxTokens` is large enough for the expected response size, or omit it to use the model's default.
+
+## Best Practices for Schema Design
+
+Follow these guidelines for reliable structured output:
+
+- **Always set `additionalProperties: false`** — This prevents the model from adding unexpected fields to the response. Without it, the model may include extra properties that your parsing code doesn't expect.
+
+- **Mark all fields as required** — List every property in the `required` array. Optional fields can lead to inconsistent responses across calls.
+
+- **Use specific types and enums** — Constrain values with `enum` arrays and specific types (`integer` vs `number`) to reduce ambiguity.
+
+- **Keep schemas focused** — Smaller, well-defined schemas produce more consistent results than large, deeply nested ones.
+
+- **Use descriptive property names** — Clear names help the model understand what data to extract without needing additional prompt instructions.
+
+Example of a well-designed schema:
+
+```swift
+let schema = try JSON(from: """
+{
+    "type": "object",
+    "properties": {
+        "city": { "type": "string" },
+        "country": { "type": "string" },
+        "population": { "type": "integer" },
+        "climate": { "type": "string", "enum": ["tropical", "arid", "temperate", "continental", "polar"] }
+    },
+    "required": ["city", "country", "population", "climate"],
+    "additionalProperties": false
+}
+""")
+```
+
+## See Also
+
+- <doc:Converse>
+- <doc:Tools>
+- <doc:Streaming>

--- a/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
@@ -138,7 +138,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 200_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .toolUse]
+            features: [.textGeneration, .systemPrompts, .document, .toolUse, .structuredOutput]
         )
     )
     public static let claudev3_5_sonnet: BedrockModel = BedrockModel(
@@ -153,7 +153,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 200_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse]
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .structuredOutput]
         )
     )
     public static let claudev3_5_sonnet_v2: BedrockModel = BedrockModel(
@@ -168,7 +168,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 200_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse]
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .structuredOutput]
         )
     )
     public static let claudev3_7_sonnet: BedrockModel = BedrockModel(
@@ -183,7 +183,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 200_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning],
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
@@ -199,7 +199,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 200_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning],
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
@@ -215,7 +215,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 200_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning],
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
@@ -231,7 +231,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 200_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning],
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
@@ -247,7 +247,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 200_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning],
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
@@ -263,7 +263,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 200_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning],
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
@@ -279,7 +279,7 @@ extension BedrockModel {
                 stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
                 maxPromptSize: 1_000_000
             ),
-            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning],
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )

--- a/Tests/Converse/ConverseRequestBuilderOutputFormatTests.swift
+++ b/Tests/Converse/ConverseRequestBuilderOutputFormatTests.swift
@@ -24,12 +24,14 @@ struct ConverseRequestBuilderOutputFormatTests {
 
     @Test("withOutputFormat stores the format on a supported model")
     func withOutputFormatStoresFormat() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "name": .object(["type": .string("string")])
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "name": .object(["type": .string("string")])
+                ]),
             ])
-        ]))
+        )
 
         let outputFormat = try OutputFormat(schema: schema, name: "test_schema", description: "A test schema")
 
@@ -43,12 +45,14 @@ struct ConverseRequestBuilderOutputFormatTests {
 
     @Test("withOutputFormat convenience with JSON schema stores the format")
     func withOutputFormatConvenienceJSON() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "age": .object(["type": .string("integer")])
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "age": .object(["type": .string("integer")])
+                ]),
             ])
-        ]))
+        )
 
         let builder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
             .withOutputFormat(schema: schema, name: "age_schema", description: "Age extraction")
@@ -152,13 +156,19 @@ struct ConverseRequestBuilderOutputFormatTests {
 
     @Test("init(from:) preserves outputFormat from source builder")
     func initFromPreservesOutputFormat() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "name": .object(["type": .string("string")])
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "name": .object(["type": .string("string")])
+                ]),
             ])
-        ]))
-        let outputFormat = try OutputFormat(schema: schema, name: "preserved_schema", description: "Should be preserved")
+        )
+        let outputFormat = try OutputFormat(
+            schema: schema,
+            name: "preserved_schema",
+            description: "Should be preserved"
+        )
 
         let sourceBuilder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
             .withPrompt("Test prompt")
@@ -185,18 +195,22 @@ struct ConverseRequestBuilderOutputFormatTests {
 
     @Test("Multiple withOutputFormat calls use the last one")
     func multipleWithOutputFormatUsesLast() throws {
-        let schema1 = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "name": .object(["type": .string("string")])
+        let schema1 = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "name": .object(["type": .string("string")])
+                ]),
             ])
-        ]))
-        let schema2 = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "age": .object(["type": .string("integer")])
+        )
+        let schema2 = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "age": .object(["type": .string("integer")])
+                ]),
             ])
-        ]))
+        )
 
         let format1 = try OutputFormat(schema: schema1, name: "first_schema", description: "First")
         let format2 = try OutputFormat(schema: schema2, name: "second_schema", description: "Second")

--- a/Tests/Converse/ConverseRequestBuilderOutputFormatTests.swift
+++ b/Tests/Converse/ConverseRequestBuilderOutputFormatTests.swift
@@ -1,0 +1,230 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import BedrockService
+
+@Suite("ConverseRequestBuilder OutputFormat Tests")
+struct ConverseRequestBuilderOutputFormatTests {
+
+    // MARK: - withOutputFormat stores the format on a supported model
+
+    @Test("withOutputFormat stores the format on a supported model")
+    func withOutputFormatStoresFormat() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object(["type": .string("string")])
+            ])
+        ]))
+
+        let outputFormat = try OutputFormat(schema: schema, name: "test_schema", description: "A test schema")
+
+        let builder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+            .withOutputFormat(outputFormat)
+
+        #expect(builder.outputFormat != nil)
+        #expect(builder.outputFormat?.name == "test_schema")
+        #expect(builder.outputFormat?.description == "A test schema")
+    }
+
+    @Test("withOutputFormat convenience with JSON schema stores the format")
+    func withOutputFormatConvenienceJSON() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "age": .object(["type": .string("integer")])
+            ])
+        ]))
+
+        let builder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+            .withOutputFormat(schema: schema, name: "age_schema", description: "Age extraction")
+
+        #expect(builder.outputFormat != nil)
+        #expect(builder.outputFormat?.name == "age_schema")
+        #expect(builder.outputFormat?.description == "Age extraction")
+    }
+
+    @Test("withOutputFormat convenience with String schema stores the format")
+    func withOutputFormatConvenienceString() throws {
+        let schemaString = """
+            {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                }
+            }
+            """
+
+        let builder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+            .withOutputFormat(schema: schemaString, name: "name_schema")
+
+        #expect(builder.outputFormat != nil)
+        #expect(builder.outputFormat?.name == "name_schema")
+        #expect(builder.outputFormat?.description == nil)
+    }
+
+    // MARK: - withOutputFormat throws on unsupported model
+
+    @Test("withOutputFormat throws invalidModality on unsupported model")
+    func withOutputFormatThrowsOnUnsupportedModel() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+        let outputFormat = try OutputFormat(schema: schema, name: "test_schema")
+
+        #expect(throws: BedrockLibraryError.self) {
+            let _ = try ConverseRequestBuilder(with: .nova_micro)
+                .withOutputFormat(outputFormat)
+        }
+    }
+
+    @Test("withOutputFormat throws specific invalidModality error on unsupported model")
+    func withOutputFormatThrowsSpecificError() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+        let outputFormat = try OutputFormat(schema: schema, name: "test_schema")
+
+        #expect {
+            try ConverseRequestBuilder(with: .nova_micro)
+                .withOutputFormat(outputFormat)
+        } throws: { error in
+            guard let bedrockError = error as? BedrockLibraryError else { return false }
+            if case .invalidModality(_, _, _) = bedrockError {
+                return true
+            }
+            return false
+        }
+    }
+
+    // MARK: - Builder immutability
+
+    @Test("withOutputFormat does not mutate the original builder")
+    func withOutputFormatImmutability() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+        let outputFormat = try OutputFormat(schema: schema, name: "test_schema")
+
+        let originalBuilder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+
+        #expect(originalBuilder.outputFormat == nil)
+
+        let newBuilder = try originalBuilder.withOutputFormat(outputFormat)
+
+        // Original builder remains unchanged
+        #expect(originalBuilder.outputFormat == nil)
+        // New builder has the format set
+        #expect(newBuilder.outputFormat != nil)
+        #expect(newBuilder.outputFormat?.name == "test_schema")
+    }
+
+    @Test("withOutputFormat does not mutate original builder with prompt set")
+    func withOutputFormatImmutabilityWithPrompt() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+        let outputFormat = try OutputFormat(schema: schema, name: "test_schema")
+
+        let originalBuilder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+            .withPrompt("Extract data")
+
+        #expect(originalBuilder.outputFormat == nil)
+        #expect(originalBuilder.prompt == "Extract data")
+
+        let newBuilder = try originalBuilder.withOutputFormat(outputFormat)
+
+        // Original builder remains unchanged
+        #expect(originalBuilder.outputFormat == nil)
+        #expect(originalBuilder.prompt == "Extract data")
+        // New builder has both prompt and format
+        #expect(newBuilder.outputFormat != nil)
+        #expect(newBuilder.prompt == "Extract data")
+    }
+
+    // MARK: - init(from:) preserves outputFormat
+
+    @Test("init(from:) preserves outputFormat from source builder")
+    func initFromPreservesOutputFormat() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object(["type": .string("string")])
+            ])
+        ]))
+        let outputFormat = try OutputFormat(schema: schema, name: "preserved_schema", description: "Should be preserved")
+
+        let sourceBuilder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+            .withPrompt("Test prompt")
+            .withOutputFormat(outputFormat)
+
+        let copiedBuilder = try ConverseRequestBuilder(from: sourceBuilder)
+
+        #expect(copiedBuilder.outputFormat != nil)
+        #expect(copiedBuilder.outputFormat?.name == "preserved_schema")
+        #expect(copiedBuilder.outputFormat?.description == "Should be preserved")
+    }
+
+    @Test("init(from:) preserves nil outputFormat from source builder")
+    func initFromPreservesNilOutputFormat() throws {
+        let sourceBuilder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+            .withPrompt("Test prompt")
+
+        let copiedBuilder = try ConverseRequestBuilder(from: sourceBuilder)
+
+        #expect(copiedBuilder.outputFormat == nil)
+    }
+
+    // MARK: - Multiple withOutputFormat calls use the last one
+
+    @Test("Multiple withOutputFormat calls use the last one")
+    func multipleWithOutputFormatUsesLast() throws {
+        let schema1 = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object(["type": .string("string")])
+            ])
+        ]))
+        let schema2 = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "age": .object(["type": .string("integer")])
+            ])
+        ]))
+
+        let format1 = try OutputFormat(schema: schema1, name: "first_schema", description: "First")
+        let format2 = try OutputFormat(schema: schema2, name: "second_schema", description: "Second")
+
+        let builder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+            .withOutputFormat(format1)
+            .withOutputFormat(format2)
+
+        #expect(builder.outputFormat?.name == "second_schema")
+        #expect(builder.outputFormat?.description == "Second")
+    }
+
+    @Test("Multiple withOutputFormat calls - intermediate builders retain their own format")
+    func multipleWithOutputFormatIntermediateBuilders() throws {
+        let schema1 = JSON(with: .object(["type": .string("object")]))
+        let schema2 = JSON(with: .object(["type": .string("array")]))
+
+        let format1 = try OutputFormat(schema: schema1, name: "first_schema")
+        let format2 = try OutputFormat(schema: schema2, name: "second_schema")
+
+        let builder1 = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+            .withOutputFormat(format1)
+
+        let builder2 = try builder1.withOutputFormat(format2)
+
+        // builder1 retains its own format
+        #expect(builder1.outputFormat?.name == "first_schema")
+        // builder2 has the new format
+        #expect(builder2.outputFormat?.name == "second_schema")
+    }
+}

--- a/Tests/Converse/ConverseRequestOutputFormatTests.swift
+++ b/Tests/Converse/ConverseRequestOutputFormatTests.swift
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+@preconcurrency import AWSBedrockRuntime
 import Testing
 
-@preconcurrency import AWSBedrockRuntime
 @testable import BedrockService
 
 @Suite("ConverseRequest OutputFormat Propagation Tests")
@@ -25,12 +25,14 @@ struct ConverseRequestOutputFormatTests {
 
     @Test("getConverseInput includes outputConfig when outputFormat is set")
     func getConverseInputIncludesOutputFormat() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "name": .object(["type": .string("string")])
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "name": .object(["type": .string("string")])
+                ]),
             ])
-        ]))
+        )
         let outputFormat = try OutputFormat(schema: schema, name: "test_schema", description: "A test")
 
         let message = Message("Hello")
@@ -59,12 +61,14 @@ struct ConverseRequestOutputFormatTests {
 
     @Test("getConverseInput outputConfig contains correct schema name and description")
     func getConverseInputOutputFormatDetails() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "age": .object(["type": .string("integer")])
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "age": .object(["type": .string("integer")])
+                ]),
             ])
-        ]))
+        )
         let outputFormat = try OutputFormat(schema: schema, name: "age_schema", description: "Age extraction")
 
         let message = Message("Extract age")
@@ -151,12 +155,14 @@ struct ConverseRequestOutputFormatTests {
 
     @Test("getConverseStreamingInput includes outputConfig when outputFormat is set")
     func getConverseStreamingInputIncludesOutputFormat() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "items": .object(["type": .string("array")])
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "items": .object(["type": .string("array")])
+                ]),
             ])
-        ]))
+        )
         let outputFormat = try OutputFormat(schema: schema, name: "items_schema")
 
         let message = Message("List items")
@@ -185,12 +191,14 @@ struct ConverseRequestOutputFormatTests {
 
     @Test("getConverseStreamingInput outputConfig contains correct schema details")
     func getConverseStreamingInputOutputFormatDetails() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "result": .object(["type": .string("string")])
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "result": .object(["type": .string("string")])
+                ]),
             ])
-        ]))
+        )
         let outputFormat = try OutputFormat(schema: schema, name: "stream_schema", description: "Streaming test")
 
         let message = Message("Stream this")

--- a/Tests/Converse/ConverseRequestOutputFormatTests.swift
+++ b/Tests/Converse/ConverseRequestOutputFormatTests.swift
@@ -1,0 +1,250 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@preconcurrency import AWSBedrockRuntime
+@testable import BedrockService
+
+@Suite("ConverseRequest OutputFormat Propagation Tests")
+struct ConverseRequestOutputFormatTests {
+
+    // MARK: - getConverseInput includes outputFormat when set
+
+    @Test("getConverseInput includes outputConfig when outputFormat is set")
+    func getConverseInputIncludesOutputFormat() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object(["type": .string("string")])
+            ])
+        ]))
+        let outputFormat = try OutputFormat(schema: schema, name: "test_schema", description: "A test")
+
+        let message = Message("Hello")
+        let history = History(message)
+
+        let request = ConverseRequest(
+            model: .claudev3_5_sonnet,
+            messages: history,
+            maxTokens: nil,
+            temperature: nil,
+            topP: nil,
+            stopSequences: nil,
+            systemPrompts: nil,
+            tools: nil,
+            maxReasoningTokens: nil,
+            serviceTier: .default,
+            outputFormat: outputFormat
+        )
+
+        let input = try request.getConverseInput(forRegion: .useast1)
+
+        #expect(input.outputConfig != nil)
+        #expect(input.outputConfig?.textFormat != nil)
+        #expect(input.outputConfig?.textFormat?.type == .jsonSchema)
+    }
+
+    @Test("getConverseInput outputConfig contains correct schema name and description")
+    func getConverseInputOutputFormatDetails() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "age": .object(["type": .string("integer")])
+            ])
+        ]))
+        let outputFormat = try OutputFormat(schema: schema, name: "age_schema", description: "Age extraction")
+
+        let message = Message("Extract age")
+        let history = History(message)
+
+        let request = ConverseRequest(
+            model: .claudev3_5_sonnet,
+            messages: history,
+            maxTokens: nil,
+            temperature: nil,
+            topP: nil,
+            stopSequences: nil,
+            systemPrompts: nil,
+            tools: nil,
+            maxReasoningTokens: nil,
+            serviceTier: .default,
+            outputFormat: outputFormat
+        )
+
+        let input = try request.getConverseInput(forRegion: .useast1)
+
+        let sdkOutputFormat = input.outputConfig?.textFormat
+        #expect(sdkOutputFormat != nil)
+
+        if case .jsonschema(let definition) = sdkOutputFormat?.structure {
+            #expect(definition.name == "age_schema")
+            #expect(definition.description == "Age extraction")
+            #expect(definition.schema != nil)
+        } else {
+            Issue.record("Expected .jsonschema structure")
+        }
+    }
+
+    // MARK: - getConverseInput has nil outputFormat when not set
+
+    @Test("getConverseInput has nil outputConfig when outputFormat is not set")
+    func getConverseInputNilOutputFormat() throws {
+        let message = Message("Hello")
+        let history = History(message)
+
+        let request = ConverseRequest(
+            model: .claudev3_5_sonnet,
+            messages: history,
+            maxTokens: nil,
+            temperature: nil,
+            topP: nil,
+            stopSequences: nil,
+            systemPrompts: nil,
+            tools: nil,
+            maxReasoningTokens: nil,
+            serviceTier: .default,
+            outputFormat: nil
+        )
+
+        let input = try request.getConverseInput(forRegion: .useast1)
+
+        #expect(input.outputConfig == nil)
+    }
+
+    @Test("getConverseInput has nil outputConfig when outputFormat defaults to nil")
+    func getConverseInputDefaultNilOutputFormat() throws {
+        let message = Message("Hello")
+        let history = History(message)
+
+        let request = ConverseRequest(
+            model: .claudev3_5_sonnet,
+            messages: history,
+            maxTokens: nil,
+            temperature: nil,
+            topP: nil,
+            stopSequences: nil,
+            systemPrompts: nil,
+            tools: nil,
+            maxReasoningTokens: nil,
+            serviceTier: .default
+        )
+
+        let input = try request.getConverseInput(forRegion: .useast1)
+
+        #expect(input.outputConfig == nil)
+    }
+
+    // MARK: - Streaming input includes outputFormat when set
+
+    @Test("getConverseStreamingInput includes outputConfig when outputFormat is set")
+    func getConverseStreamingInputIncludesOutputFormat() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "items": .object(["type": .string("array")])
+            ])
+        ]))
+        let outputFormat = try OutputFormat(schema: schema, name: "items_schema")
+
+        let message = Message("List items")
+        let history = History(message)
+
+        let request = ConverseRequest(
+            model: .claudev3_5_sonnet,
+            messages: history,
+            maxTokens: nil,
+            temperature: nil,
+            topP: nil,
+            stopSequences: nil,
+            systemPrompts: nil,
+            tools: nil,
+            maxReasoningTokens: nil,
+            serviceTier: .default,
+            outputFormat: outputFormat
+        )
+
+        let streamInput = try request.getConverseStreamingInput(forRegion: .useast1)
+
+        #expect(streamInput.outputConfig != nil)
+        #expect(streamInput.outputConfig?.textFormat != nil)
+        #expect(streamInput.outputConfig?.textFormat?.type == .jsonSchema)
+    }
+
+    @Test("getConverseStreamingInput outputConfig contains correct schema details")
+    func getConverseStreamingInputOutputFormatDetails() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "result": .object(["type": .string("string")])
+            ])
+        ]))
+        let outputFormat = try OutputFormat(schema: schema, name: "stream_schema", description: "Streaming test")
+
+        let message = Message("Stream this")
+        let history = History(message)
+
+        let request = ConverseRequest(
+            model: .claudev3_5_sonnet,
+            messages: history,
+            maxTokens: nil,
+            temperature: nil,
+            topP: nil,
+            stopSequences: nil,
+            systemPrompts: nil,
+            tools: nil,
+            maxReasoningTokens: nil,
+            serviceTier: .default,
+            outputFormat: outputFormat
+        )
+
+        let streamInput = try request.getConverseStreamingInput(forRegion: .useast1)
+
+        let sdkOutputFormat = streamInput.outputConfig?.textFormat
+        #expect(sdkOutputFormat != nil)
+
+        if case .jsonschema(let definition) = sdkOutputFormat?.structure {
+            #expect(definition.name == "stream_schema")
+            #expect(definition.description == "Streaming test")
+            #expect(definition.schema != nil)
+        } else {
+            Issue.record("Expected .jsonschema structure")
+        }
+    }
+
+    @Test("getConverseStreamingInput has nil outputConfig when outputFormat is not set")
+    func getConverseStreamingInputNilOutputFormat() throws {
+        let message = Message("Hello")
+        let history = History(message)
+
+        let request = ConverseRequest(
+            model: .claudev3_5_sonnet,
+            messages: history,
+            maxTokens: nil,
+            temperature: nil,
+            topP: nil,
+            stopSequences: nil,
+            systemPrompts: nil,
+            tools: nil,
+            maxReasoningTokens: nil,
+            serviceTier: .default,
+            outputFormat: nil
+        )
+
+        let streamInput = try request.getConverseStreamingInput(forRegion: .useast1)
+
+        #expect(streamInput.outputConfig == nil)
+    }
+}

--- a/Tests/Converse/ConverseToolTests.swift
+++ b/Tests/Converse/ConverseToolTests.swift
@@ -17,6 +17,82 @@ import Testing
 
 @testable import BedrockService
 
+// MARK: - Tool strict parameter tests
+
+@Suite("Tool Strict Parameter Tests")
+struct ToolStrictParameterTests {
+
+    @Test("Tool with strict true stores strict as true")
+    func toolWithStrictTrue() throws {
+        let tool = try Tool(
+            name: "my_tool",
+            inputSchema: JSON(with: .object(["type": .string("object")])),
+            description: "A test tool",
+            strict: true
+        )
+
+        #expect(tool.strict == true)
+    }
+
+    @Test("Tool without strict parameter defaults to false")
+    func toolWithoutStrictDefaultsToFalse() throws {
+        let tool = try Tool(
+            name: "my_tool",
+            inputSchema: JSON(with: .object(["type": .string("object")])),
+            description: "A test tool"
+        )
+
+        #expect(tool.strict == false)
+    }
+
+    @Test("getSDKToolSpecification returns strict true when strict is true")
+    func sdkToolSpecStrictTrue() throws {
+        let tool = try Tool(
+            name: "my_tool",
+            inputSchema: JSON(with: .object(["type": .string("object")])),
+            description: "A test tool",
+            strict: true
+        )
+
+        let spec = try tool.getSDKToolSpecification()
+
+        #expect(spec.strict == true)
+    }
+
+    @Test("getSDKToolSpecification returns strict nil when strict is false")
+    func sdkToolSpecStrictNil() throws {
+        let tool = try Tool(
+            name: "my_tool",
+            inputSchema: JSON(with: .object(["type": .string("object")])),
+            description: "A test tool",
+            strict: false
+        )
+
+        let spec = try tool.getSDKToolSpecification()
+
+        #expect(spec.strict == nil)
+    }
+
+    @Test("Backward compatibility: existing initializer without strict compiles and works")
+    func backwardCompatibility() throws {
+        // This test verifies that the existing initializer signature
+        // Tool(name:inputSchema:description:) still works without the strict parameter
+        let tool = try Tool(
+            name: "legacy_tool",
+            inputSchema: JSON(with: .object(["type": .string("object")])),
+            description: "A legacy tool"
+        )
+
+        #expect(tool.name == "legacy_tool")
+        #expect(tool.toolDescription == "A legacy tool")
+        #expect(tool.strict == false)
+
+        // Also verify the SDK spec omits strict (nil) for backward-compatible tools
+        let spec = try tool.getSDKToolSpecification()
+        #expect(spec.strict == nil)
+    }
+}
+
 // Converse tools
 extension BedrockServiceTests {
 

--- a/Tests/Converse/ImmutableBuilderPropertyTests.swift
+++ b/Tests/Converse/ImmutableBuilderPropertyTests.swift
@@ -1,0 +1,200 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+/// **Validates: Requirements 4.6, 4.7**
+///
+/// Property 7: Immutable Builder
+/// For any builder and valid OutputFormat, calling `withOutputFormat` returns a new builder
+/// with the format set, and the original builder remains unchanged
+@Suite("Immutable Builder Property Tests")
+struct ImmutableBuilderPropertyTests {
+
+    // MARK: - Custom Generators
+
+    /// Characters allowed in OutputFormat names: [a-zA-Z0-9_-]
+    private static let validNameCharacters = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+    /// Generates a random valid name matching pattern [a-zA-Z0-9_-]+
+    private static func generateValidName() -> String {
+        let length = Int.random(in: 1...40)
+        return String((0..<length).map { _ in validNameCharacters.randomElement()! })
+    }
+
+    /// Generates a random optional description
+    private static func generateDescription() -> String? {
+        guard Bool.random() else { return nil }
+        let words = ["extraction", "schema", "output", "format", "data", "result", "response", "model", "test", "config"]
+        let wordCount = Int.random(in: 1...5)
+        return (0..<wordCount).map { _ in words.randomElement()! }.joined(separator: " ")
+    }
+
+    /// Generates a random valid JSON schema as a JSON value
+    private static func generateValidJSONSchema() -> JSON {
+        let propertyTypes = ["string", "integer", "number", "boolean"]
+        let propertyCount = Int.random(in: 0...6)
+
+        var properties: [String: JSONValue] = [:]
+        var propertyNames: [String] = []
+
+        for i in 0..<propertyCount {
+            let propName = "field_\(i)_\(generateValidName().prefix(6))"
+            let propType = propertyTypes.randomElement()!
+            properties[propName] = .object(["type": .string(propType)])
+            propertyNames.append(propName)
+        }
+
+        var schemaObject: [String: JSONValue] = [
+            "type": .string("object")
+        ]
+
+        if !properties.isEmpty {
+            schemaObject["properties"] = .object(properties)
+
+            // Randomly add required fields
+            if !propertyNames.isEmpty && Bool.random() {
+                let requiredCount = Int.random(in: 1...propertyNames.count)
+                let required = Array(propertyNames.shuffled().prefix(requiredCount))
+                schemaObject["required"] = .array(required.map { .string($0) })
+            }
+        }
+
+        // Randomly add additionalProperties: false
+        if Bool.random() {
+            schemaObject["additionalProperties"] = .bool(false)
+        }
+
+        return JSON(with: .object(schemaObject))
+    }
+
+    /// Generates a random valid OutputFormat instance
+    private static func generateValidOutputFormat() throws -> OutputFormat {
+        let schema = generateValidJSONSchema()
+        let name = generateValidName()
+        let description = generateDescription()
+        return try OutputFormat(schema: schema, name: name, description: description)
+    }
+
+    // MARK: - Property Tests
+
+    @Test("Property: withOutputFormat returns new builder with format set, original remains unchanged")
+    func immutableBuilderProperty() throws {
+        let iterations = 100
+
+        for _ in 0..<iterations {
+            let outputFormat = try Self.generateValidOutputFormat()
+
+            // Create a builder for a model that supports structured output
+            let originalBuilder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+
+            // Verify original has no outputFormat
+            #expect(
+                originalBuilder.outputFormat == nil,
+                "Original builder should have nil outputFormat before calling withOutputFormat"
+            )
+
+            // Call withOutputFormat
+            let newBuilder = try originalBuilder.withOutputFormat(outputFormat)
+
+            // Assert: the returned builder has the outputFormat set
+            #expect(
+                newBuilder.outputFormat != nil,
+                "New builder should have outputFormat set after calling withOutputFormat"
+            )
+            #expect(
+                newBuilder.outputFormat?.name == outputFormat.name,
+                "New builder's outputFormat name should match the provided format's name '\(outputFormat.name)'"
+            )
+            #expect(
+                newBuilder.outputFormat?.description == outputFormat.description,
+                "New builder's outputFormat description should match the provided format's description"
+            )
+
+            // Assert: the original builder's outputFormat remains nil (unchanged)
+            #expect(
+                originalBuilder.outputFormat == nil,
+                "Original builder's outputFormat should remain nil after calling withOutputFormat, but got name: \(originalBuilder.outputFormat?.name ?? "nil")"
+            )
+        }
+    }
+
+    @Test("Property: withOutputFormat preserves immutability when original builder has a prompt set")
+    func immutableBuilderWithPromptProperty() throws {
+        let iterations = 100
+
+        for _ in 0..<iterations {
+            let outputFormat = try Self.generateValidOutputFormat()
+
+            // Create a builder with a prompt already set
+            let originalBuilder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+                .withPrompt("Test prompt for property testing")
+
+            // Verify original state
+            #expect(originalBuilder.outputFormat == nil)
+            #expect(originalBuilder.prompt == "Test prompt for property testing")
+
+            // Call withOutputFormat
+            let newBuilder = try originalBuilder.withOutputFormat(outputFormat)
+
+            // Assert: new builder has the format set and retains the prompt
+            #expect(newBuilder.outputFormat != nil)
+            #expect(newBuilder.outputFormat?.name == outputFormat.name)
+            #expect(newBuilder.prompt == "Test prompt for property testing")
+
+            // Assert: original builder remains unchanged
+            #expect(
+                originalBuilder.outputFormat == nil,
+                "Original builder's outputFormat should remain nil, but got name: \(originalBuilder.outputFormat?.name ?? "nil")"
+            )
+            #expect(originalBuilder.prompt == "Test prompt for property testing")
+        }
+    }
+
+    @Test("Property: chaining withOutputFormat multiple times preserves immutability of intermediate builders")
+    func immutableBuilderChainingProperty() throws {
+        let iterations = 50
+
+        for _ in 0..<iterations {
+            let format1 = try Self.generateValidOutputFormat()
+            let format2 = try Self.generateValidOutputFormat()
+
+            let baseBuilder = try ConverseRequestBuilder(with: .claudev3_5_sonnet)
+            let builder1 = try baseBuilder.withOutputFormat(format1)
+            let builder2 = try builder1.withOutputFormat(format2)
+
+            // Assert: base builder remains unchanged
+            #expect(
+                baseBuilder.outputFormat == nil,
+                "Base builder should remain nil after chaining withOutputFormat calls"
+            )
+
+            // Assert: builder1 retains format1
+            #expect(
+                builder1.outputFormat?.name == format1.name,
+                "First intermediate builder should retain its own format '\(format1.name)', but got '\(builder1.outputFormat?.name ?? "nil")'"
+            )
+
+            // Assert: builder2 has format2
+            #expect(
+                builder2.outputFormat?.name == format2.name,
+                "Final builder should have the last format '\(format2.name)', but got '\(builder2.outputFormat?.name ?? "nil")'"
+            )
+        }
+    }
+}

--- a/Tests/Converse/ImmutableBuilderPropertyTests.swift
+++ b/Tests/Converse/ImmutableBuilderPropertyTests.swift
@@ -40,7 +40,9 @@ struct ImmutableBuilderPropertyTests {
     /// Generates a random optional description
     private static func generateDescription() -> String? {
         guard Bool.random() else { return nil }
-        let words = ["extraction", "schema", "output", "format", "data", "result", "response", "model", "test", "config"]
+        let words = [
+            "extraction", "schema", "output", "format", "data", "result", "response", "model", "test", "config",
+        ]
         let wordCount = Int.random(in: 1...5)
         return (0..<wordCount).map { _ in words.randomElement()! }.joined(separator: " ")
     }

--- a/Tests/Converse/NameValidationConsistencyPropertyTests.swift
+++ b/Tests/Converse/NameValidationConsistencyPropertyTests.swift
@@ -1,0 +1,300 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+/// **Validates: Requirements 7.1, 7.2**
+///
+/// Property 3: Name Validation Consistency
+/// For any string, OutputFormat name validation and Tool name validation
+/// produce the same accept/reject result — both use the pattern [a-zA-Z0-9_-]+
+/// and reject empty strings.
+@Suite("Name Validation Consistency Property Tests")
+struct NameValidationConsistencyPropertyTests {
+
+    // A valid JSON schema to use when creating OutputFormat instances
+    private let validSchema = JSON(with: .object(["type": .string("object")]))
+
+    // A valid JSON input schema to use when creating Tool instances
+    private let validInputSchema = JSON(with: .object(["type": .string("object")]))
+
+    /// Attempts to create an OutputFormat with the given name.
+    /// Returns true if creation succeeds, false if it throws.
+    private func outputFormatAccepts(_ name: String) -> Bool {
+        do {
+            let _ = try OutputFormat(schema: validSchema, name: name)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Attempts to create a Tool with the given name.
+    /// Returns true if creation succeeds, false if it throws.
+    private func toolAccepts(_ name: String) -> Bool {
+        do {
+            let _ = try Tool(name: name, inputSchema: validInputSchema)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Returns the error thrown when creating an OutputFormat with the given name, or nil if no error.
+    private func outputFormatError(_ name: String) -> BedrockLibraryError? {
+        do {
+            let _ = try OutputFormat(schema: validSchema, name: name)
+            return nil
+        } catch let error as BedrockLibraryError {
+            return error
+        } catch {
+            return nil
+        }
+    }
+
+    /// Returns the error thrown when creating a Tool with the given name, or nil if no error.
+    private func toolError(_ name: String) -> BedrockLibraryError? {
+        do {
+            let _ = try Tool(name: name, inputSchema: validInputSchema)
+            return nil
+        } catch let error as BedrockLibraryError {
+            return error
+        } catch {
+            return nil
+        }
+    }
+
+    /// Generates a variety of test strings covering valid names, empty strings,
+    /// strings with special characters, unicode, spaces, etc.
+    private var testNames: [String] {
+        var names: [String] = []
+
+        // Empty string
+        names.append("")
+
+        // Valid names: alphanumeric, underscores, hyphens
+        names.append("a")
+        names.append("Z")
+        names.append("0")
+        names.append("_")
+        names.append("-")
+        names.append("valid_name")
+        names.append("valid-name")
+        names.append("ValidName123")
+        names.append("a-b_c-d")
+        names.append("ALLCAPS")
+        names.append("lowercase")
+        names.append("MiXeD_CaSe-123")
+        names.append("___")
+        names.append("---")
+        names.append("a_b_c")
+        names.append("test-schema_v2")
+        names.append("x")
+        names.append("A1_b2-C3")
+
+        // Strings with special characters (should be rejected if they contain ONLY invalid chars)
+        names.append("!!!")
+        names.append("@#$")
+        names.append("...")
+        names.append("***")
+        names.append("   ")
+        names.append("\t\t")
+        names.append("~~~")
+        names.append("()")
+        names.append("[]")
+        names.append("{}")
+        names.append("<>")
+        names.append("++=")
+        names.append("///")
+        names.append("\\\\")
+        names.append("|||")
+        names.append("^^^")
+        names.append("&&&")
+        names.append("%%%")
+
+        // Mixed: valid chars mixed with invalid chars (contains match)
+        names.append("hello world")
+        names.append("name with spaces")
+        names.append("name@domain")
+        names.append("path/to/file")
+        names.append("key=value")
+        names.append("hello!")
+        names.append("test.name")
+        names.append("name\ttab")
+        names.append("name\nnewline")
+        names.append("a b")
+        names.append(" leading")
+        names.append("trailing ")
+        names.append("mid dle")
+
+        // Unicode characters
+        names.append("café")
+        names.append("日本語")
+        names.append("émoji")
+        names.append("über")
+        names.append("naïve")
+        names.append("🎉")
+        names.append("hello🌍")
+        names.append("αβγ")
+        names.append("中文名")
+
+        // Edge cases
+        names.append(String(repeating: "a", count: 1))
+        names.append(String(repeating: "a", count: 100))
+        names.append(String(repeating: "-", count: 50))
+        names.append(String(repeating: "_", count: 50))
+
+        // Randomly generated strings with various character sets
+        let validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+        let invalidChars = " !@#$%^&*()+=[]{}|;:',.<>?/~`\"\\\t\n"
+
+        // Generate random valid names
+        for length in 1...10 {
+            var name = ""
+            for _ in 0..<length {
+                let index = validChars.index(
+                    validChars.startIndex,
+                    offsetBy: Int.random(in: 0..<validChars.count)
+                )
+                name.append(validChars[index])
+            }
+            names.append(name)
+        }
+
+        // Generate random invalid-only names
+        for length in 1...5 {
+            var name = ""
+            for _ in 0..<length {
+                let index = invalidChars.index(
+                    invalidChars.startIndex,
+                    offsetBy: Int.random(in: 0..<invalidChars.count)
+                )
+                name.append(invalidChars[index])
+            }
+            names.append(name)
+        }
+
+        // Generate random mixed names (valid + invalid chars)
+        let allChars = validChars + invalidChars
+        for length in 2...8 {
+            var name = ""
+            for _ in 0..<length {
+                let index = allChars.index(
+                    allChars.startIndex,
+                    offsetBy: Int.random(in: 0..<allChars.count)
+                )
+                name.append(allChars[index])
+            }
+            names.append(name)
+        }
+
+        return names
+    }
+
+    // MARK: - Property Test
+
+    @Test("Property 3: OutputFormat and Tool name validation produce the same accept/reject result for all strings")
+    func nameValidationConsistency() throws {
+        for name in testNames {
+            let outputFormatResult = outputFormatAccepts(name)
+            let toolResult = toolAccepts(name)
+
+            #expect(
+                outputFormatResult == toolResult,
+                "Name validation inconsistency for \"\(name)\": OutputFormat \(outputFormatResult ? "accepts" : "rejects"), Tool \(toolResult ? "accepts" : "rejects")"
+            )
+        }
+    }
+
+    @Test("Property 3: When both reject a name, both throw BedrockLibraryError.invalidName")
+    func bothRejectWithInvalidNameError() throws {
+        for name in testNames {
+            let ofError = outputFormatError(name)
+            let toolErr = toolError(name)
+
+            // If both reject, verify both throw invalidName
+            if ofError != nil && toolErr != nil {
+                #expect(
+                    ofError == BedrockLibraryError.invalidName(""),
+                    "OutputFormat should throw invalidName for \"\(name)\", got: \(String(describing: ofError))"
+                )
+                #expect(
+                    toolErr == BedrockLibraryError.invalidName(""),
+                    "Tool should throw invalidName for \"\(name)\", got: \(String(describing: toolErr))"
+                )
+            }
+
+            // If one accepts and the other rejects, that's a consistency violation
+            let ofAccepts = ofError == nil
+            let toolAccepts = toolErr == nil
+            #expect(
+                ofAccepts == toolAccepts,
+                "Name validation inconsistency for \"\(name)\": OutputFormat \(ofAccepts ? "accepts" : "rejects"), Tool \(toolAccepts ? "accepts" : "rejects")"
+            )
+        }
+    }
+
+    @Test("Property 3: Known valid names are accepted by both OutputFormat and Tool")
+    func knownValidNamesAcceptedByBoth() throws {
+        let validNames = [
+            "a", "Z", "0", "_", "-",
+            "valid_name", "valid-name", "ValidName123",
+            "a-b_c-d", "ALLCAPS", "lowercase",
+            "MiXeD_CaSe-123", "test-schema_v2",
+        ]
+
+        for name in validNames {
+            #expect(
+                outputFormatAccepts(name),
+                "OutputFormat should accept valid name \"\(name)\""
+            )
+            #expect(
+                toolAccepts(name),
+                "Tool should accept valid name \"\(name)\""
+            )
+        }
+    }
+
+    @Test("Property 3: Empty string is rejected by both OutputFormat and Tool")
+    func emptyStringRejectedByBoth() throws {
+        #expect(!outputFormatAccepts(""))
+        #expect(!toolAccepts(""))
+
+        let ofError = outputFormatError("")
+        let toolErr = toolError("")
+
+        #expect(ofError == BedrockLibraryError.invalidName(""))
+        #expect(toolErr == BedrockLibraryError.invalidName(""))
+    }
+
+    @Test("Property 3: Strings with only invalid characters are rejected by both")
+    func invalidOnlyStringsRejectedByBoth() throws {
+        let invalidOnlyNames = ["!!!", "@#$", "...", "***", "   ", "~~~", "()", "[]", "{}"]
+
+        for name in invalidOnlyNames {
+            #expect(
+                !outputFormatAccepts(name),
+                "OutputFormat should reject invalid-only name \"\(name)\""
+            )
+            #expect(
+                !toolAccepts(name),
+                "Tool should reject invalid-only name \"\(name)\""
+            )
+        }
+    }
+}

--- a/Tests/Converse/OutputFormatTests.swift
+++ b/Tests/Converse/OutputFormatTests.swift
@@ -26,12 +26,14 @@ struct OutputFormatTests {
 
     @Test("Create OutputFormat with valid JSON schema and valid name")
     func createWithValidJSONAndName() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "name": .object(["type": .string("string")])
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "name": .object(["type": .string("string")])
+                ]),
             ])
-        ]))
+        )
 
         let outputFormat = try OutputFormat(schema: schema, name: "test_schema")
 
@@ -206,12 +208,14 @@ struct OutputFormatTests {
 
     @Test("getSDKOutputFormat returns SDK type with .jsonSchema type")
     func sdkOutputFormatHasJsonSchemaType() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "name": .object(["type": .string("string")])
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "name": .object(["type": .string("string")])
+                ]),
             ])
-        ]))
+        )
 
         let outputFormat = try OutputFormat(schema: schema, name: "test_schema")
         let sdkFormat = try outputFormat.getSDKOutputFormat()
@@ -221,14 +225,16 @@ struct OutputFormatTests {
 
     @Test("getSDKOutputFormat schema string round-trips correctly")
     func sdkOutputFormatSchemaRoundTrips() throws {
-        let schema = JSON(with: .object([
-            "type": .string("object"),
-            "properties": .object([
-                "name": .object(["type": .string("string")]),
-                "age": .object(["type": .string("integer")])
-            ]),
-            "required": .array([.string("name"), .string("age")])
-        ]))
+        let schema = JSON(
+            with: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "name": .object(["type": .string("string")]),
+                    "age": .object(["type": .string("integer")]),
+                ]),
+                "required": .array([.string("name"), .string("age")]),
+            ])
+        )
 
         let outputFormat = try OutputFormat(schema: schema, name: "person_schema")
         let sdkFormat = try outputFormat.getSDKOutputFormat()

--- a/Tests/Converse/OutputFormatTests.swift
+++ b/Tests/Converse/OutputFormatTests.swift
@@ -1,0 +1,298 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@preconcurrency import AWSBedrockRuntime
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+@Suite("OutputFormat Tests")
+struct OutputFormatTests {
+
+    // MARK: - Successful creation with valid JSON value and valid name
+
+    @Test("Create OutputFormat with valid JSON schema and valid name")
+    func createWithValidJSONAndName() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object(["type": .string("string")])
+            ])
+        ]))
+
+        let outputFormat = try OutputFormat(schema: schema, name: "test_schema")
+
+        #expect(outputFormat.name == "test_schema")
+        #expect(outputFormat.description == nil)
+        #expect(outputFormat.schema["type"] == "object")
+    }
+
+    @Test("Create OutputFormat with name containing hyphens and underscores")
+    func createWithHyphensAndUnderscores() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        let outputFormat = try OutputFormat(schema: schema, name: "my-schema_v2")
+
+        #expect(outputFormat.name == "my-schema_v2")
+    }
+
+    @Test("Create OutputFormat with alphanumeric name")
+    func createWithAlphanumericName() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        let outputFormat = try OutputFormat(schema: schema, name: "Schema123")
+
+        #expect(outputFormat.name == "Schema123")
+    }
+
+    // MARK: - Creation with and without description
+
+    @Test("Create OutputFormat with description")
+    func createWithDescription() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        let outputFormat = try OutputFormat(
+            schema: schema,
+            name: "person_info",
+            description: "A schema for person information"
+        )
+
+        #expect(outputFormat.name == "person_info")
+        #expect(outputFormat.description == "A schema for person information")
+    }
+
+    @Test("Create OutputFormat without description")
+    func createWithoutDescription() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        let outputFormat = try OutputFormat(schema: schema, name: "person_info")
+
+        #expect(outputFormat.description == nil)
+    }
+
+    // MARK: - Creation from JSON string
+
+    @Test("Create OutputFormat from valid JSON string")
+    func createFromValidJSONString() throws {
+        let schemaString = """
+            {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "age": { "type": "integer" }
+                },
+                "required": ["name", "age"]
+            }
+            """
+
+        let outputFormat = try OutputFormat(schema: schemaString, name: "person_schema")
+
+        #expect(outputFormat.name == "person_schema")
+        #expect(outputFormat.schema["type"] == "object")
+    }
+
+    // MARK: - Failure for null JSON schema
+
+    @Test("Fail creation with null JSON schema")
+    func failWithNullSchema() throws {
+        let nullSchema = JSON(with: .null)
+
+        #expect(throws: BedrockLibraryError.self) {
+            let _ = try OutputFormat(schema: nullSchema, name: "test_schema")
+        }
+    }
+
+    @Test("Fail creation with null JSON schema throws .invalid error")
+    func failWithNullSchemaThrowsInvalid() throws {
+        let nullSchema = JSON(with: .null)
+
+        #expect {
+            try OutputFormat(schema: nullSchema, name: "test_schema")
+        } throws: { error in
+            guard let bedrockError = error as? BedrockLibraryError else { return false }
+            return bedrockError == BedrockLibraryError.invalid("OutputFormat schema must not be null")
+        }
+    }
+
+    // MARK: - Failure for invalid JSON string
+
+    @Test("Fail creation with invalid JSON string")
+    func failWithInvalidJSONString() throws {
+        let invalidJSON = "{ this is not valid json }"
+
+        #expect(throws: BedrockLibraryError.self) {
+            let _ = try OutputFormat(schema: invalidJSON, name: "test_schema")
+        }
+    }
+
+    @Test("Fail creation with invalid JSON string throws decodingError")
+    func failWithInvalidJSONStringThrowsDecodingError() throws {
+        let invalidJSON = "{ not valid json"
+
+        #expect {
+            try OutputFormat(schema: invalidJSON, name: "test_schema")
+        } throws: { error in
+            guard let bedrockError = error as? BedrockLibraryError else { return false }
+            return bedrockError == BedrockLibraryError.decodingError("")
+        }
+    }
+
+    // MARK: - Failure for empty name
+
+    @Test("Fail creation with empty name")
+    func failWithEmptyName() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        #expect(throws: BedrockLibraryError.self) {
+            let _ = try OutputFormat(schema: schema, name: "")
+        }
+    }
+
+    @Test("Fail creation with empty name throws invalidName error")
+    func failWithEmptyNameThrowsInvalidName() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        #expect {
+            try OutputFormat(schema: schema, name: "")
+        } throws: { error in
+            guard let bedrockError = error as? BedrockLibraryError else { return false }
+            return bedrockError == BedrockLibraryError.invalidName("")
+        }
+    }
+
+    // MARK: - Failure for name with invalid characters
+
+    @Test("Fail creation with name containing only special characters")
+    func failWithSpecialCharsOnlyName() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        #expect(throws: BedrockLibraryError.self) {
+            let _ = try OutputFormat(schema: schema, name: "!!!")
+        }
+    }
+
+    @Test("Fail creation with name containing only dots")
+    func failWithDotsOnlyName() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        #expect(throws: BedrockLibraryError.self) {
+            let _ = try OutputFormat(schema: schema, name: "...")
+        }
+    }
+
+    @Test("Fail creation with name containing only spaces")
+    func failWithSpacesOnlyName() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        #expect(throws: BedrockLibraryError.self) {
+            let _ = try OutputFormat(schema: schema, name: "   ")
+        }
+    }
+
+    // MARK: - getSDKOutputFormat() tests
+
+    @Test("getSDKOutputFormat returns SDK type with .jsonSchema type")
+    func sdkOutputFormatHasJsonSchemaType() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object(["type": .string("string")])
+            ])
+        ]))
+
+        let outputFormat = try OutputFormat(schema: schema, name: "test_schema")
+        let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+        #expect(sdkFormat.type == .jsonSchema)
+    }
+
+    @Test("getSDKOutputFormat schema string round-trips correctly")
+    func sdkOutputFormatSchemaRoundTrips() throws {
+        let schema = JSON(with: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object(["type": .string("string")]),
+                "age": .object(["type": .string("integer")])
+            ]),
+            "required": .array([.string("name"), .string("age")])
+        ]))
+
+        let outputFormat = try OutputFormat(schema: schema, name: "person_schema")
+        let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+        // Extract the schema string from the SDK structure
+        guard case .jsonschema(let definition) = sdkFormat.structure else {
+            Issue.record("Expected .jsonschema structure")
+            return
+        }
+
+        let schemaString = try #require(definition.schema)
+
+        // Parse the schema string back to JSON and verify it matches the original
+        let parsedBack = try JSON(from: schemaString)
+        #expect(parsedBack["type"] == "object")
+        #expect(parsedBack["required"] != nil)
+    }
+
+    @Test("getSDKOutputFormat sets name correctly")
+    func sdkOutputFormatSetsName() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        let outputFormat = try OutputFormat(schema: schema, name: "my-schema_v2")
+        let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+        guard case .jsonschema(let definition) = sdkFormat.structure else {
+            Issue.record("Expected .jsonschema structure")
+            return
+        }
+
+        #expect(definition.name == "my-schema_v2")
+    }
+
+    @Test("getSDKOutputFormat sets description correctly")
+    func sdkOutputFormatSetsDescription() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        let outputFormat = try OutputFormat(
+            schema: schema,
+            name: "test_schema",
+            description: "A test schema description"
+        )
+        let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+        guard case .jsonschema(let definition) = sdkFormat.structure else {
+            Issue.record("Expected .jsonschema structure")
+            return
+        }
+
+        #expect(definition.description == "A test schema description")
+    }
+
+    @Test("getSDKOutputFormat sets nil description when not provided")
+    func sdkOutputFormatNilDescription() throws {
+        let schema = JSON(with: .object(["type": .string("object")]))
+
+        let outputFormat = try OutputFormat(schema: schema, name: "test_schema")
+        let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+        guard case .jsonschema(let definition) = sdkFormat.structure else {
+            Issue.record("Expected .jsonschema structure")
+            return
+        }
+
+        #expect(definition.description == nil)
+    }
+}

--- a/Tests/Converse/SchemaPreservationPropertyTests.swift
+++ b/Tests/Converse/SchemaPreservationPropertyTests.swift
@@ -106,26 +106,26 @@ struct SchemaPreservationPropertyTests {
         let innerProperties: [String: JSONValue] = [
             "street": .object(["type": .string("string")]),
             "city": .object(["type": .string("string")]),
-            "zip": .object(["type": .string("string")])
+            "zip": .object(["type": .string("string")]),
         ]
 
         let innerSchema: [String: JSONValue] = [
             "type": .string("object"),
             "properties": .object(innerProperties),
-            "required": .array([.string("street"), .string("city")])
+            "required": .array([.string("street"), .string("city")]),
         ]
 
         let outerProperties: [String: JSONValue] = [
             "name": .object(["type": .string("string")]),
             "age": .object(["type": .string("integer")]),
-            "address": .object(innerSchema)
+            "address": .object(innerSchema),
         ]
 
         let schemaObject: [String: JSONValue] = [
             "type": .string("object"),
             "properties": .object(outerProperties),
             "required": .array([.string("name")]),
-            "additionalProperties": .bool(false)
+            "additionalProperties": .bool(false),
         ]
 
         return JSON(with: .object(schemaObject))
@@ -143,16 +143,16 @@ struct SchemaPreservationPropertyTests {
 
         let arrayProp: [String: JSONValue] = [
             "type": .string("array"),
-            "items": .object(itemsSchema)
+            "items": .object(itemsSchema),
         ]
 
         let schemaObject: [String: JSONValue] = [
             "type": .string("object"),
             "properties": .object([
                 "items_list": .object(arrayProp),
-                "count": .object(["type": .string("integer")])
+                "count": .object(["type": .string("integer")]),
             ]),
-            "required": .array([.string("items_list")])
+            "required": .array([.string("items_list")]),
         ]
 
         return JSON(with: .object(schemaObject))

--- a/Tests/Converse/SchemaPreservationPropertyTests.swift
+++ b/Tests/Converse/SchemaPreservationPropertyTests.swift
@@ -1,0 +1,344 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@preconcurrency import AWSBedrockRuntime
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+/// **Validates: Requirements 1.2, 1.3, 2.2**
+///
+/// Property 2: Schema Preservation
+/// For any valid JSON schema and valid name, `OutputFormat(schema:name:).getSDKOutputFormat()`
+/// produces a JsonSchemaDefinition whose schema string, when parsed back, is semantically
+/// equivalent to the original.
+@Suite("Schema Preservation Property Tests")
+struct SchemaPreservationPropertyTests {
+
+    // MARK: - Custom Generators
+
+    /// Characters allowed in OutputFormat names: [a-zA-Z0-9_-]
+    private static let validNameCharacters = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+    /// Generates a random valid name matching pattern [a-zA-Z0-9_-]+
+    private static func generateValidName() -> String {
+        let length = Int.random(in: 1...40)
+        return String((0..<length).map { _ in validNameCharacters.randomElement()! })
+    }
+
+    /// Generates a random valid JSON schema with varying complexity
+    private static func generateValidJSONSchema() -> JSON {
+        let propertyTypes = ["string", "integer", "number", "boolean"]
+        let propertyCount = Int.random(in: 0...8)
+
+        var properties: [String: JSONValue] = [:]
+        var propertyNames: [String] = []
+
+        for i in 0..<propertyCount {
+            let propName = "prop_\(i)_\(String(generateValidName().prefix(6)))"
+            let propType = propertyTypes.randomElement()!
+
+            var propSchema: [String: JSONValue] = ["type": .string(propType)]
+
+            // Randomly add extra constraints
+            if propType == "string" && Bool.random() {
+                propSchema["minLength"] = .int(Int.random(in: 0...10))
+            }
+            if propType == "integer" && Bool.random() {
+                propSchema["minimum"] = .int(Int.random(in: 0...100))
+            }
+            if propType == "number" && Bool.random() {
+                propSchema["maximum"] = .double(Double.random(in: 0...1000))
+            }
+
+            properties[propName] = .object(propSchema)
+            propertyNames.append(propName)
+        }
+
+        var schemaObject: [String: JSONValue] = [
+            "type": .string("object")
+        ]
+
+        if !properties.isEmpty {
+            schemaObject["properties"] = .object(properties)
+
+            // Randomly add required fields
+            if !propertyNames.isEmpty && Bool.random() {
+                let requiredCount = Int.random(in: 1...propertyNames.count)
+                let required = Array(propertyNames.shuffled().prefix(requiredCount))
+                schemaObject["required"] = .array(required.map { .string($0) })
+            }
+        }
+
+        // Randomly add additionalProperties: false
+        if Bool.random() {
+            schemaObject["additionalProperties"] = .bool(false)
+        }
+
+        // Randomly add a description
+        if Bool.random() {
+            schemaObject["description"] = .string("Generated schema \(Int.random(in: 1...999))")
+        }
+
+        // Randomly add a title
+        if Bool.random() {
+            schemaObject["title"] = .string("Schema_\(Int.random(in: 1...999))")
+        }
+
+        return JSON(with: .object(schemaObject))
+    }
+
+    /// Generates a schema with nested objects for deeper structure testing
+    private static func generateNestedJSONSchema() -> JSON {
+        let innerProperties: [String: JSONValue] = [
+            "street": .object(["type": .string("string")]),
+            "city": .object(["type": .string("string")]),
+            "zip": .object(["type": .string("string")])
+        ]
+
+        let innerSchema: [String: JSONValue] = [
+            "type": .string("object"),
+            "properties": .object(innerProperties),
+            "required": .array([.string("street"), .string("city")])
+        ]
+
+        let outerProperties: [String: JSONValue] = [
+            "name": .object(["type": .string("string")]),
+            "age": .object(["type": .string("integer")]),
+            "address": .object(innerSchema)
+        ]
+
+        let schemaObject: [String: JSONValue] = [
+            "type": .string("object"),
+            "properties": .object(outerProperties),
+            "required": .array([.string("name")]),
+            "additionalProperties": .bool(false)
+        ]
+
+        return JSON(with: .object(schemaObject))
+    }
+
+    /// Generates a schema with array types
+    private static func generateArrayJSONSchema() -> JSON {
+        let itemTypes = ["string", "integer", "number", "boolean"]
+        let itemType = itemTypes.randomElement()!
+
+        var itemsSchema: [String: JSONValue] = ["type": .string(itemType)]
+        if itemType == "string" && Bool.random() {
+            itemsSchema["enum"] = .array([.string("a"), .string("b"), .string("c")])
+        }
+
+        let arrayProp: [String: JSONValue] = [
+            "type": .string("array"),
+            "items": .object(itemsSchema)
+        ]
+
+        let schemaObject: [String: JSONValue] = [
+            "type": .string("object"),
+            "properties": .object([
+                "items_list": .object(arrayProp),
+                "count": .object(["type": .string("integer")])
+            ]),
+            "required": .array([.string("items_list")])
+        ]
+
+        return JSON(with: .object(schemaObject))
+    }
+
+    // MARK: - Semantic Equivalence Helper
+
+    /// Compares two JSONValue instances for semantic equivalence.
+    /// Objects are compared regardless of key ordering.
+    /// Arrays are compared element-by-element in order.
+    private static func isSemanticEqual(_ lhs: JSONValue, _ rhs: JSONValue) -> Bool {
+        switch (lhs, rhs) {
+        case (.null, .null):
+            return true
+        case (.int(let a), .int(let b)):
+            return a == b
+        case (.double(let a), .double(let b)):
+            return a == b
+        case (.int(let a), .double(let b)):
+            return Double(a) == b
+        case (.double(let a), .int(let b)):
+            return a == Double(b)
+        case (.string(let a), .string(let b)):
+            return a == b
+        case (.bool(let a), .bool(let b)):
+            return a == b
+        case (.array(let a), .array(let b)):
+            guard a.count == b.count else { return false }
+            return zip(a, b).allSatisfy { isSemanticEqual($0, $1) }
+        case (.object(let a), .object(let b)):
+            guard a.count == b.count else { return false }
+            for (key, value) in a {
+                guard let otherValue = b[key] else { return false }
+                if !isSemanticEqual(value, otherValue) { return false }
+            }
+            return true
+        default:
+            return false
+        }
+    }
+
+    // MARK: - Property Tests
+
+    @Test("Property 2: Schema is preserved through OutputFormat -> getSDKOutputFormat() -> parse round-trip")
+    func schemaPreservationProperty() throws {
+        let iterations = 100
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidName()
+            let schema = Self.generateValidJSONSchema()
+
+            // Create OutputFormat with the generated schema and name
+            let outputFormat = try OutputFormat(schema: schema, name: name)
+
+            // Convert to SDK format
+            let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+            // Extract the schema string from the SDK structure
+            guard case .jsonschema(let definition) = sdkFormat.structure else {
+                Issue.record("Expected .jsonschema structure for name: \(name)")
+                continue
+            }
+
+            let schemaString = try #require(
+                definition.schema,
+                "Schema string should not be nil for name: \(name)"
+            )
+
+            // Parse the schema string back to JSON
+            let parsedBack = try JSON(from: schemaString)
+
+            // Verify semantic equivalence
+            #expect(
+                Self.isSemanticEqual(schema.value, parsedBack.value),
+                "Schema not preserved for name: \(name). Original: \(schema.value), Parsed back: \(parsedBack.value)"
+            )
+        }
+    }
+
+    @Test("Property 2: Nested schemas are preserved through the round-trip")
+    func nestedSchemaPreservation() throws {
+        let iterations = 50
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidName()
+            let schema = Self.generateNestedJSONSchema()
+
+            let outputFormat = try OutputFormat(schema: schema, name: name)
+            let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+            guard case .jsonschema(let definition) = sdkFormat.structure else {
+                Issue.record("Expected .jsonschema structure for nested schema with name: \(name)")
+                continue
+            }
+
+            let schemaString = try #require(definition.schema)
+            let parsedBack = try JSON(from: schemaString)
+
+            #expect(
+                Self.isSemanticEqual(schema.value, parsedBack.value),
+                "Nested schema not preserved for name: \(name)"
+            )
+        }
+    }
+
+    @Test("Property 2: Array schemas are preserved through the round-trip")
+    func arraySchemaPreservation() throws {
+        let iterations = 50
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidName()
+            let schema = Self.generateArrayJSONSchema()
+
+            let outputFormat = try OutputFormat(schema: schema, name: name)
+            let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+            guard case .jsonschema(let definition) = sdkFormat.structure else {
+                Issue.record("Expected .jsonschema structure for array schema with name: \(name)")
+                continue
+            }
+
+            let schemaString = try #require(definition.schema)
+            let parsedBack = try JSON(from: schemaString)
+
+            #expect(
+                Self.isSemanticEqual(schema.value, parsedBack.value),
+                "Array schema not preserved for name: \(name)"
+            )
+        }
+    }
+
+    @Test("Property 2: Name is preserved in the SDK output format")
+    func namePreservation() throws {
+        let iterations = 100
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidName()
+            let schema = Self.generateValidJSONSchema()
+
+            let outputFormat = try OutputFormat(schema: schema, name: name)
+            let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+            guard case .jsonschema(let definition) = sdkFormat.structure else {
+                Issue.record("Expected .jsonschema structure for name: \(name)")
+                continue
+            }
+
+            #expect(
+                definition.name == name,
+                "Name not preserved. Expected: \(name), Got: \(String(describing: definition.name))"
+            )
+        }
+    }
+
+    @Test("Property 2: Schema preservation works with string-initialized OutputFormat")
+    func schemaPreservationFromString() throws {
+        let iterations = 50
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidName()
+            let schema = Self.generateValidJSONSchema()
+
+            // Serialize the schema to a JSON string first
+            let encoder = JSONEncoder()
+            let schemaData = try encoder.encode(schema)
+            let schemaString = try #require(String(data: schemaData, encoding: .utf8))
+
+            // Create OutputFormat from the string
+            let outputFormat = try OutputFormat(schema: schemaString, name: name)
+
+            // Convert to SDK format
+            let sdkFormat = try outputFormat.getSDKOutputFormat()
+
+            guard case .jsonschema(let definition) = sdkFormat.structure else {
+                Issue.record("Expected .jsonschema structure for string-initialized schema with name: \(name)")
+                continue
+            }
+
+            let resultSchemaString = try #require(definition.schema)
+            let parsedBack = try JSON(from: resultSchemaString)
+
+            // Verify semantic equivalence with the original schema
+            #expect(
+                Self.isSemanticEqual(schema.value, parsedBack.value),
+                "Schema not preserved through string initialization for name: \(name)"
+            )
+        }
+    }
+}

--- a/Tests/Converse/StrictToolMappingPropertyTests.swift
+++ b/Tests/Converse/StrictToolMappingPropertyTests.swift
@@ -1,0 +1,161 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+/// **Validates: Requirements 3.3, 3.4**
+///
+/// Property 6: Strict Tool Mapping
+/// For any Tool with `strict == true`, `getSDKToolSpecification().strict == true`;
+/// for `strict == false`, `getSDKToolSpecification().strict == nil`
+@Suite("Strict Tool Mapping Property Tests")
+struct StrictToolMappingPropertyTests {
+
+    // MARK: - Custom Generators
+
+    /// Characters allowed in tool names: [a-zA-Z0-9_-]
+    private static let validNameCharacters = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+    /// Generates a random valid tool name matching pattern [a-zA-Z0-9_-]+
+    private static func generateValidToolName() -> String {
+        let length = Int.random(in: 1...50)
+        return String((0..<length).map { _ in validNameCharacters.randomElement()! })
+    }
+
+    /// Generates a random valid JSON schema as a JSON value
+    private static func generateValidJSONSchema() -> JSON {
+        let propertyTypes = ["string", "integer", "number", "boolean"]
+        let propertyCount = Int.random(in: 0...5)
+
+        var properties: [String: JSONValue] = [:]
+        var propertyNames: [String] = []
+
+        for i in 0..<propertyCount {
+            let propName = "prop_\(i)_\(generateValidToolName().prefix(8))"
+            let propType = propertyTypes.randomElement()!
+            properties[propName] = .object(["type": .string(propType)])
+            propertyNames.append(propName)
+        }
+
+        var schemaObject: [String: JSONValue] = [
+            "type": .string("object")
+        ]
+
+        if !properties.isEmpty {
+            schemaObject["properties"] = .object(properties)
+
+            // Randomly add some required fields
+            if !propertyNames.isEmpty && Bool.random() {
+                let requiredCount = Int.random(in: 1...propertyNames.count)
+                let required = Array(propertyNames.shuffled().prefix(requiredCount))
+                schemaObject["required"] = .array(required.map { .string($0) })
+            }
+        }
+
+        // Randomly add additionalProperties: false
+        if Bool.random() {
+            schemaObject["additionalProperties"] = .bool(false)
+        }
+
+        return JSON(with: .object(schemaObject))
+    }
+
+    // MARK: - Property Tests
+
+    @Test("Property: Tool with strict == true maps to SDK strict == true")
+    func strictTrueMapsToSDKTrue() throws {
+        let iterations = 100
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidToolName()
+            let schema = Self.generateValidJSONSchema()
+
+            let tool = try Tool(
+                name: name,
+                inputSchema: schema,
+                description: "Auto-generated tool for property testing",
+                strict: true
+            )
+
+            #expect(tool.strict == true, "Tool created with strict: true should have strict == true for name: \(name)")
+
+            let spec = try tool.getSDKToolSpecification()
+            #expect(spec.strict == true, "Tool with strict: true should have SDK strict == true, but got \(String(describing: spec.strict)) for name: \(name)")
+        }
+    }
+
+    @Test("Property: Tool with strict == false maps to SDK strict == nil")
+    func strictFalseMapsToSDKNil() throws {
+        let iterations = 100
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidToolName()
+            let schema = Self.generateValidJSONSchema()
+
+            let tool = try Tool(
+                name: name,
+                inputSchema: schema,
+                description: "Auto-generated tool for property testing",
+                strict: false
+            )
+
+            #expect(tool.strict == false, "Tool created with strict: false should have strict == false for name: \(name)")
+
+            let spec = try tool.getSDKToolSpecification()
+            #expect(spec.strict == nil, "Tool with strict: false should have SDK strict == nil, but got \(String(describing: spec.strict)) for name: \(name)")
+        }
+    }
+
+    @Test("Property: Strict mapping is consistent for both values on same input")
+    func strictMappingConsistentForBothValues() throws {
+        let iterations = 100
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidToolName()
+            let schema = Self.generateValidJSONSchema()
+
+            // Create tool with strict: true
+            let strictTool = try Tool(
+                name: name,
+                inputSchema: schema,
+                description: "Tool for consistency check",
+                strict: true
+            )
+
+            // Create tool with strict: false using same name and schema
+            let nonStrictTool = try Tool(
+                name: name,
+                inputSchema: schema,
+                description: "Tool for consistency check",
+                strict: false
+            )
+
+            let strictSpec = try strictTool.getSDKToolSpecification()
+            let nonStrictSpec = try nonStrictTool.getSDKToolSpecification()
+
+            // strict: true -> SDK strict == true
+            #expect(strictSpec.strict == true, "strict: true tool should map to SDK strict == true for name: \(name)")
+
+            // strict: false -> SDK strict == nil
+            #expect(nonStrictSpec.strict == nil, "strict: false tool should map to SDK strict == nil for name: \(name)")
+
+            // Both tools should have the same name in the SDK spec
+            #expect(strictSpec.name == nonStrictSpec.name, "Both tools should have the same name in SDK spec")
+        }
+    }
+}

--- a/Tests/Converse/StrictToolMappingPropertyTests.swift
+++ b/Tests/Converse/StrictToolMappingPropertyTests.swift
@@ -95,7 +95,10 @@ struct StrictToolMappingPropertyTests {
             #expect(tool.strict == true, "Tool created with strict: true should have strict == true for name: \(name)")
 
             let spec = try tool.getSDKToolSpecification()
-            #expect(spec.strict == true, "Tool with strict: true should have SDK strict == true, but got \(String(describing: spec.strict)) for name: \(name)")
+            #expect(
+                spec.strict == true,
+                "Tool with strict: true should have SDK strict == true, but got \(String(describing: spec.strict)) for name: \(name)"
+            )
         }
     }
 
@@ -114,10 +117,16 @@ struct StrictToolMappingPropertyTests {
                 strict: false
             )
 
-            #expect(tool.strict == false, "Tool created with strict: false should have strict == false for name: \(name)")
+            #expect(
+                tool.strict == false,
+                "Tool created with strict: false should have strict == false for name: \(name)"
+            )
 
             let spec = try tool.getSDKToolSpecification()
-            #expect(spec.strict == nil, "Tool with strict: false should have SDK strict == nil, but got \(String(describing: spec.strict)) for name: \(name)")
+            #expect(
+                spec.strict == nil,
+                "Tool with strict: false should have SDK strict == nil, but got \(String(describing: spec.strict)) for name: \(name)"
+            )
         }
     }
 

--- a/Tests/Converse/ToolBackwardCompatibilityPropertyTests.swift
+++ b/Tests/Converse/ToolBackwardCompatibilityPropertyTests.swift
@@ -94,11 +94,17 @@ struct ToolBackwardCompatibilityPropertyTests {
             )
 
             // Assert: strict defaults to false
-            #expect(tool.strict == false, "Tool created without strict parameter should have strict == false, but got true for name: \(name)")
+            #expect(
+                tool.strict == false,
+                "Tool created without strict parameter should have strict == false, but got true for name: \(name)"
+            )
 
             // Assert: SDK specification has strict == nil
             let spec = try tool.getSDKToolSpecification()
-            #expect(spec.strict == nil, "Tool created without strict parameter should have SDK strict == nil, but got \(String(describing: spec.strict)) for name: \(name)")
+            #expect(
+                spec.strict == nil,
+                "Tool created without strict parameter should have SDK strict == nil, but got \(String(describing: spec.strict)) for name: \(name)"
+            )
         }
     }
 

--- a/Tests/Converse/ToolBackwardCompatibilityPropertyTests.swift
+++ b/Tests/Converse/ToolBackwardCompatibilityPropertyTests.swift
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+/// **Validates: Requirements 3.2, 3.4, 3.5**
+///
+/// Property 1: Backward Compatibility
+/// For any valid tool name and schema, creating a Tool without the strict parameter
+/// results in `strict == false` and `getSDKToolSpecification().strict == nil`
+@Suite("Tool Backward Compatibility Property Tests")
+struct ToolBackwardCompatibilityPropertyTests {
+
+    // MARK: - Custom Generators
+
+    /// Characters allowed in tool names: [a-zA-Z0-9_-]
+    private static let validNameCharacters = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+    /// Generates a random valid tool name matching pattern [a-zA-Z0-9_-]+
+    private static func generateValidToolName() -> String {
+        let length = Int.random(in: 1...50)
+        return String((0..<length).map { _ in validNameCharacters.randomElement()! })
+    }
+
+    /// Generates a random valid JSON schema as a JSON value
+    private static func generateValidJSONSchema() -> JSON {
+        let propertyTypes = ["string", "integer", "number", "boolean"]
+        let propertyCount = Int.random(in: 0...5)
+
+        var properties: [String: JSONValue] = [:]
+        var propertyNames: [String] = []
+
+        for i in 0..<propertyCount {
+            let propName = "prop_\(i)_\(generateValidToolName().prefix(8))"
+            let propType = propertyTypes.randomElement()!
+            properties[propName] = .object(["type": .string(propType)])
+            propertyNames.append(propName)
+        }
+
+        var schemaObject: [String: JSONValue] = [
+            "type": .string("object")
+        ]
+
+        if !properties.isEmpty {
+            schemaObject["properties"] = .object(properties)
+
+            // Randomly add some required fields
+            if !propertyNames.isEmpty && Bool.random() {
+                let requiredCount = Int.random(in: 1...propertyNames.count)
+                let required = Array(propertyNames.shuffled().prefix(requiredCount))
+                schemaObject["required"] = .array(required.map { .string($0) })
+            }
+        }
+
+        // Randomly add additionalProperties: false
+        if Bool.random() {
+            schemaObject["additionalProperties"] = .bool(false)
+        }
+
+        return JSON(with: .object(schemaObject))
+    }
+
+    // MARK: - Property Test
+
+    @Test("Property: Tool without strict parameter has strict == false and SDK strict == nil")
+    func backwardCompatibilityProperty() throws {
+        // Run the property across many random inputs
+        let iterations = 100
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidToolName()
+            let schema = Self.generateValidJSONSchema()
+
+            // Create a Tool WITHOUT the strict parameter (backward-compatible usage)
+            let tool = try Tool(
+                name: name,
+                inputSchema: schema,
+                description: "Auto-generated tool for property testing"
+            )
+
+            // Assert: strict defaults to false
+            #expect(tool.strict == false, "Tool created without strict parameter should have strict == false, but got true for name: \(name)")
+
+            // Assert: SDK specification has strict == nil
+            let spec = try tool.getSDKToolSpecification()
+            #expect(spec.strict == nil, "Tool created without strict parameter should have SDK strict == nil, but got \(String(describing: spec.strict)) for name: \(name)")
+        }
+    }
+
+    @Test("Property: Tool without strict parameter preserves name and description")
+    func backwardCompatibilityPreservesFields() throws {
+        let iterations = 100
+
+        for _ in 0..<iterations {
+            let name = Self.generateValidToolName()
+            let schema = Self.generateValidJSONSchema()
+            let description = Bool.random() ? "Description for \(name)" : nil
+
+            let tool = try Tool(
+                name: name,
+                inputSchema: schema,
+                description: description
+            )
+
+            // Verify backward-compatible behavior: fields are preserved correctly
+            #expect(tool.name == name)
+            #expect(tool.toolDescription == description)
+            #expect(tool.strict == false)
+
+            let spec = try tool.getSDKToolSpecification()
+            #expect(spec.name == name)
+            #expect(spec.description == description)
+            #expect(spec.strict == nil)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds structured output support to the Swift Bedrock Library, enabling developers to constrain model responses to conform to a specified JSON schema.

## Changes

- **OutputFormat type** — New struct with JSON schema validation, name validation, and SDK conversion
- **Tool strict parameter** — Extends Tool with `strict: Bool` for constrained tool input validation
- **ConverseRequestBuilder** — New `withOutputFormat` fluent API methods
- **Request propagation** — OutputFormat flows through ConverseRequest and streaming requests to the SDK
- **ConverseFeature** — New `.structuredOutput` case, enabled for Anthropic Claude models
- **Tests** — Unit tests and property-based tests covering all new functionality
- **Documentation** — DocC article explaining both JSON schema output format and strict tool use
- **Example app** — `Examples/structured-output/` demonstrating both mechanisms
- **CI** — Added structured-output example to the integration test workflow

## Testing

- All 163 tests pass (`swift test`)
- Example compiles and runs successfully
- Property-based tests validate: backward compatibility, schema preservation, name validation consistency, strict tool mapping, and builder immutability

Closes #70