### PR TITLE
Add Claude Opus 4.8 support

### DIFF
--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/Role.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/Role.swift
@@ -37,6 +37,10 @@ public struct Role: Codable, Sendable, Equatable, CustomStringConvertible {
             throw BedrockLibraryError.notImplemented(
                 "Role \(unknownRole) is not implemented by BedrockRuntimeClientTypes"
             )
+        @unknown default:
+            throw BedrockLibraryError.notImplemented(
+                "Role \(sdkConversationRole) is not implemented by BedrockRuntimeClientTypes"
+            )
         }
     }
 

--- a/Sources/BedrockService/BedrockRuntimeClient/Converse/Role.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Converse/Role.swift
@@ -33,6 +33,10 @@ public struct Role: Codable, Sendable, Equatable, CustomStringConvertible {
         switch sdkConversationRole {
         case .user: self.type = .user
         case .assistant: self.type = .assistant
+        case .system:
+            throw BedrockLibraryError.notImplemented(
+                "Role system is not yet supported by the Swift Bedrock Library"
+            )
         case .sdkUnknown(let unknownRole):
             throw BedrockLibraryError.notImplemented(
                 "Role \(unknownRole) is not implemented by BedrockRuntimeClientTypes"

--- a/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
@@ -283,4 +283,20 @@ extension BedrockModel {
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
+    public static let claude_opus_v4_8: BedrockModel = BedrockModel(
+        id: "anthropic.claude-opus-4-8",
+        name: "Claude Opus v4.8",
+        modality: Claude_Opus_v4_8(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 128_000, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 0.999),
+                topK: Parameter(.topK, minValue: 0, maxValue: 500, defaultValue: 0),
+                stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
+                maxPromptSize: 1_000_000
+            ),
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
+            maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
+        )
+    )
 }

--- a/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
@@ -208,3 +208,51 @@ struct Claude_Opus_v4_7: TextModality, ConverseModality, ConverseStreamingModali
         try anthropicText.getTextResponseBody(from: data)
     }
 }
+
+struct Claude_Opus_v4_8: TextModality, ConverseModality, ConverseStreamingModality,
+    GlobalCrossRegionInferenceModality
+{
+    private let anthropicText: AnthropicText
+
+    let converseParameters: ConverseParameters
+    let converseFeatures: [ConverseFeature]
+
+    init(parameters: TextGenerationParameters, features: [ConverseFeature], maxReasoningTokens: Parameter<Int>) {
+        self.anthropicText = AnthropicText(
+            parameters: parameters,
+            features: features,
+            maxReasoningTokens: maxReasoningTokens
+        )
+        self.converseParameters = anthropicText.converseParameters
+        self.converseFeatures = anthropicText.converseFeatures
+    }
+
+    func getName() -> String { anthropicText.getName() }
+    func getParameters() -> TextGenerationParameters { anthropicText.getParameters() }
+    func getConverseParameters() -> ConverseParameters { anthropicText.getConverseParameters() }
+    func getConverseFeatures() -> [ConverseFeature] { anthropicText.getConverseFeatures() }
+
+    func getTextRequestBody(
+        prompt: String,
+        maxTokens: Int?,
+        temperature: Double?,
+        topP: Double?,
+        topK: Int?,
+        stopSequences: [String]?,
+        serviceTier: ServiceTier
+    ) throws -> BedrockBodyCodable {
+        try anthropicText.getTextRequestBody(
+            prompt: prompt,
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            stopSequences: stopSequences,
+            serviceTier: serviceTier
+        )
+    }
+
+    func getTextResponseBody(from data: Data) throws -> ContainsTextCompletion {
+        try anthropicText.getTextResponseBody(from: data)
+    }
+}

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -87,6 +87,8 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
             self = BedrockModel.claude_opus_v4_6
         case BedrockModel.claude_opus_v4_7.id:
             self = BedrockModel.claude_opus_v4_7
+        case BedrockModel.claude_opus_v4_8.id:
+            self = BedrockModel.claude_opus_v4_8
         // titan
         case BedrockModel.titan_text_g1_premier.id:
             self = BedrockModel.titan_text_g1_premier


### PR DESCRIPTION
## Summary
- Add Claude Opus v4.8 model with 128K max output tokens, 1M context window, and global cross-region inference support
- Fix pre-existing build error in `Role.swift` caused by an unhandled `.system` case added in a newer AWS SDK version (added `@unknown default` for future-proofing)

## Test plan
- [x] `swift build` passes locally
- [x] CI build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)