### PR TITLE
Add OpenAI Responses API support (GPT 5.5, 5.4, gpt-oss)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,7 +109,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'api-key', 'converse', 'converse-stream', 'embeddings', 'openai', 'retrieve', 'stability-image', 'structured-output', 'text_chat' ]"
+      examples: "[ 'api-key', 'converse', 'converse-stream', 'embeddings', 'openai', 'responses', 'retrieve', 'stability-image', 'structured-output', 'text_chat' ]"
 
   swift-6-language-mode:
     name: Swift 6 Language Mode

--- a/.kiro/specs/openai-responses-api/design.md
+++ b/.kiro/specs/openai-responses-api/design.md
@@ -1,0 +1,199 @@
+# Design Document: OpenAI Responses API (Bedrock-Mantle)
+
+## Overview
+
+This feature adds support for the OpenAI Responses API on the `bedrock-mantle` endpoint. This enables:
+- **New models**: GPT 5.5 and GPT 5.4 (Responses API only — no Invoke/Converse/ChatCompletions)
+- **Existing models via mantle**: gpt-oss-120b and gpt-oss-20b already support Invoke+Converse, and we now also expose them via the Responses API
+
+The implementation introduces:
+1. **ResponsesModality protocol** — marks models that support the Responses API
+2. **BedrockMantleClient** — HTTP client for the bedrock-mantle endpoint using `AsyncHTTPClient`
+3. **Dual authentication** — API key (Bearer token) and SigV4 signing
+4. **BedrockService.createResponse()** — public API on the existing service struct
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "Public API"
+        BS[BedrockService]
+        BM[BedrockModel]
+        BMA[BedrockMantleAuthentication]
+    end
+
+    subgraph "New Types"
+        RM[ResponsesModality]
+        RI[ResponsesRequestBody]
+        RO[ResponsesOutput]
+    end
+
+    subgraph "HTTP Layer"
+        BMCP[BedrockMantleClientProtocol]
+        BMC[BedrockMantleClient]
+        AHC[AsyncHTTPClient]
+    end
+
+    subgraph "Auth"
+        AK[API Key - Bearer Token]
+        SV[SigV4 - AwsCommonRuntimeKit.Signer]
+    end
+
+    BS -->|"createResponse()"| BMCP
+    BS --> BM
+    BM --> RM
+    BMCP --> BMC
+    BMC --> AHC
+    BMC --> AK
+    BMC --> SV
+    BS --> RI
+    BMCP --> RO
+```
+
+## Key Design Decisions
+
+### 1. Why AsyncHTTPClient (not URLSession)?
+
+- Already a transitive dependency via aws-sdk-swift — no new dependencies
+- Server-side Swift compatible (works on Linux)
+- Non-blocking, built on SwiftNIO
+- The project targets macOS 15+ AND Linux (CI runs on Amazon Linux 2023)
+
+### 2. Why not the MacPaw/OpenAI library?
+
+- Adds `swift-openapi-runtime` as a transitive dependency
+- Overkill — we only need a single POST endpoint
+- Would couple the library to an external community project
+
+### 3. Path routing by model
+
+GPT 5.5/5.4 use `/openai/v1/responses` while gpt-oss models use `/v1/responses`. The path is stored in the `OpenAIResponses` modality struct and retrieved via `getResponsesPath()`. This lets us support both variants without conditional logic in the client.
+
+### 4. Authentication design
+
+```swift
+public enum BedrockMantleAuthentication: Sendable {
+    case apiKey(String)
+    case sigV4
+}
+```
+
+- **API key**: Simple Bearer token in the `Authorization` header. User creates key in the Bedrock console.
+- **SigV4**: Uses the CRT Signer with existing AWS credentials. Service name is `bedrock`, region from BedrockService.
+
+### 5. No streaming (initial scope)
+
+The Responses API supports `"stream": true` but we defer streaming to a follow-up. The initial implementation is synchronous request/response only.
+
+## Endpoint Details
+
+| Property | Value |
+|---|---|
+| Base URL | `https://bedrock-mantle.{region}.api.aws` |
+| Method | POST |
+| Path (GPT 5.5/5.4) | `/openai/v1/responses` |
+| Path (gpt-oss) | `/v1/responses` |
+| Content-Type | `application/json` |
+| Auth (API key) | `Authorization: Bearer {key}` |
+| Auth (SigV4) | Standard AWS SigV4 signing (service: `bedrock`) |
+
+## Request Format
+
+```json
+{
+    "model": "openai.gpt-5.5",
+    "input": [
+        {"role": "user", "content": "Hello! How can you help me today?"}
+    ],
+    "store": false
+}
+```
+
+## Response Format (simplified)
+
+```json
+{
+    "id": "resp_abc123",
+    "object": "response",
+    "model": "openai.gpt-5.5",
+    "output": [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": "Hello! I can help you with..."}
+            ]
+        }
+    ],
+    "usage": {
+        "input_tokens": 10,
+        "output_tokens": 25,
+        "total_tokens": 35
+    }
+}
+```
+
+## Models Supporting the Responses API
+
+| Model | Model ID | Responses Path | Also supports Invoke/Converse | Status |
+|---|---|---|---|---|
+| GPT 5.5 | `openai.gpt-5.5` | `/openai/v1/responses` | No | **New model** |
+| GPT 5.4 | `openai.gpt-5.4` | `/openai/v1/responses` | No | **New model** |
+| gpt-oss-120b | `openai.gpt-oss-120b-1:0` | `/v1/responses` | Yes (already in library) | **Add ResponsesModality** |
+| gpt-oss-20b | `openai.gpt-oss-20b-1:0` | `/v1/responses` | Yes (already in library) | **Add ResponsesModality** |
+
+### New Model Specs
+
+| | GPT 5.5 | GPT 5.4 |
+|---|---|---|
+| Model ID | `openai.gpt-5.5` | `openai.gpt-5.4` |
+| Context window | 272K tokens | 272K tokens |
+| Input modalities | Text, Image | Text, Image |
+| Output modalities | Text | Text |
+| Cross-region | Not supported | Not supported |
+| Service tiers | Standard only | Standard only |
+| Regions | us-east-2 | us-east-2, us-west-2 |
+
+### Existing Model Changes
+
+The existing `OpenAIText` struct (used by gpt-oss-20b and gpt-oss-120b) will additionally conform to `ResponsesModality`, returning path `/v1/responses`. This means these models keep their current Invoke+Converse capabilities AND gain Responses API support.
+
+## Bedrock-Mantle Supported Regions
+
+us-east-1, us-east-2, us-west-2, ap-southeast-3, ap-south-1, ap-southeast-2, ap-northeast-1, eu-central-1, eu-west-1, eu-west-2, eu-south-1, eu-north-1, sa-east-1
+
+## File Structure
+
+```
+Sources/BedrockService/
+├── BedrockRuntimeClient/
+│   ├── Modalities/
+│   │   └── ResponsesModality.swift          (NEW)
+│   └── Responses/
+│       ├── BedrockMantleAuthentication.swift (NEW)
+│       ├── BedrockMantleClientProtocol.swift (NEW)
+│       ├── BedrockMantleClient.swift         (NEW)
+│       ├── ResponsesInput.swift             (NEW)
+│       ├── ResponsesOutput.swift            (NEW)
+│       └── BedrockService+Responses.swift   (NEW)
+└── Models/
+    └── OpenAI/
+        ├── OpenAI.swift                     (MODIFIED - add ResponsesModality conformance)
+        ├── OpenAIBedrockModels.swift        (MODIFIED - add GPT 5.5/5.4)
+        └── OpenAIResponses.swift            (NEW - responses-only modality for GPT 5.5/5.4)
+
+Tests/
+├── Responses/
+│   ├── ResponsesModelTests.swift            (NEW)
+│   ├── ResponsesRequestTests.swift          (NEW)
+│   ├── ResponsesResponseTests.swift         (NEW)
+│   └── ResponsesServiceTests.swift          (NEW)
+└── Mock/
+    └── MockBedrockMantleClient.swift        (NEW)
+
+Examples/
+└── responses/
+    ├── Package.swift                        (NEW)
+    └── Sources/
+        └── Responses.swift                  (NEW)
+```

--- a/.kiro/specs/openai-responses-api/requirements.md
+++ b/.kiro/specs/openai-responses-api/requirements.md
@@ -1,0 +1,117 @@
+# Requirements Document
+
+## Introduction
+
+This document defines the requirements for adding OpenAI GPT 5.5 and GPT 5.4 model support to the Swift Bedrock Library via the Responses API on the `bedrock-mantle` endpoint. These models only support the Responses API — they do not support Invoke, Converse, or Chat Completions. The implementation introduces a new `bedrock-mantle` HTTP client using `AsyncHTTPClient`, a new `ResponsesModality` protocol, and supports both API key and SigV4 authentication.
+
+## Glossary
+
+- **bedrock-mantle**: An AWS endpoint (`bedrock-mantle.{region}.api.aws`) that serves OpenAI-compatible APIs (Responses, Chat Completions, Models) for Amazon Bedrock.
+- **Responses API**: OpenAI's stateful conversation API (`POST /v1/responses`) supporting multi-turn interactions, tool use, and conversation history management.
+- **ResponsesModality**: A new protocol for models that support the Responses API (as opposed to Converse or Invoke).
+- **BedrockMantleClient**: A new HTTP client that communicates with the bedrock-mantle endpoint.
+- **BedrockMantleAuthentication**: An enum representing auth modes — API key (Bearer token) or SigV4.
+- **AsyncHTTPClient**: The swift-server HTTP client library (already a transitive dependency).
+- **SigV4**: AWS Signature Version 4, the standard AWS request signing mechanism.
+
+## Requirements
+
+### Requirement 1: ResponsesModality Protocol
+
+**User Story:** As a developer, I want to identify which models support the Responses API, so I can use the correct API surface.
+
+#### Acceptance Criteria
+
+1. THE `ResponsesModality` protocol SHALL extend `Modality`
+2. THE `ResponsesModality` protocol SHALL declare a method `getResponsesPath() -> String` returning the API path for the model
+3. Models using path `/openai/v1/responses` (GPT 5.5, GPT 5.4) SHALL return that path
+4. Models using path `/v1/responses` (gpt-oss) SHALL return that path
+5. `BedrockModel` SHALL provide `hasResponsesModality() -> Bool` and `getResponsesModality() throws -> any ResponsesModality`
+
+### Requirement 2: Model Definitions
+
+**User Story:** As a developer, I want to use `.openai_gpt_5_5` and `.openai_gpt_5_4` model constants, and also use existing gpt-oss models via the Responses API.
+
+#### Acceptance Criteria
+
+1. `BedrockModel.openai_gpt_5_5` SHALL have id `"openai.gpt-5.5"` and name `"OpenAI GPT 5.5"`
+2. `BedrockModel.openai_gpt_5_4` SHALL have id `"openai.gpt-5.4"` and name `"OpenAI GPT 5.4"`
+3. GPT 5.5 and 5.4 SHALL use `OpenAIResponses` modality with path `/openai/v1/responses`
+4. GPT 5.5 and 5.4 SHALL NOT have converse, text, or streaming modality
+5. Both new models SHALL be resolvable via `BedrockModel(rawValue:)`
+6. Both new models SHALL NOT support cross-region inference
+7. Existing `.openai_gpt_oss_20b` and `.openai_gpt_oss_120b` SHALL additionally conform to `ResponsesModality` with path `/v1/responses`
+8. Existing gpt-oss models SHALL retain their current Invoke and Converse capabilities unchanged
+
+### Requirement 3: BedrockMantleAuthentication
+
+**User Story:** As a developer, I want to authenticate to the bedrock-mantle endpoint using either an API key or my existing AWS credentials.
+
+#### Acceptance Criteria
+
+1. `BedrockMantleAuthentication` SHALL support `.apiKey(String)` — sets `Authorization: Bearer {key}` header
+2. `BedrockMantleAuthentication` SHALL support `.sigV4` — signs the request using AWS credentials via `AwsCommonRuntimeKit.Signer`
+3. THE enum SHALL conform to `Sendable`
+
+### Requirement 4: BedrockMantleClient
+
+**User Story:** As a developer, I want the library to handle HTTP communication with the bedrock-mantle endpoint transparently.
+
+#### Acceptance Criteria
+
+1. `BedrockMantleClientProtocol` SHALL define an async method for sending a request and receiving a response
+2. `BedrockMantleClient` SHALL use `AsyncHTTPClient` for HTTP POST requests
+3. THE client SHALL build the URL as `https://bedrock-mantle.{region}.api.aws{path}` where path comes from the model's `ResponsesModality`
+4. THE client SHALL set `Content-Type: application/json` header
+5. FOR `.apiKey` auth, THE client SHALL set `Authorization: Bearer {key}` header
+6. FOR `.sigV4` auth, THE client SHALL sign the request using `AwsCommonRuntimeKit.Signer.signRequest()` with service `bedrock`
+7. THE client SHALL throw appropriate errors for HTTP 4xx/5xx responses
+8. THE client SHALL conform to `Sendable`
+
+### Requirement 5: Request/Response Types
+
+**User Story:** As a developer, I want properly typed request and response structures matching the OpenAI Responses API format.
+
+#### Acceptance Criteria
+
+1. THE request body SHALL include `model` (String), `input` (array of messages with role/content), and optional `store` (Bool)
+2. Each input message SHALL have a `role` (String: "user", "assistant", "system") and `content` (String)
+3. THE response SHALL expose `id` (String), extracted text output, `model` (String), and `usage` (input/output token counts)
+4. THE response type SHALL provide a convenience method to extract the text reply
+5. All types SHALL conform to `Sendable`
+
+### Requirement 6: BedrockService Integration
+
+**User Story:** As a developer, I want to call `bedrock.createResponse(...)` to invoke models via the Responses API, keeping the single-entry-point pattern.
+
+#### Acceptance Criteria
+
+1. `BedrockService` SHALL expose a public method `createResponse(_:with:authentication:store:) async throws -> ResponsesOutput`
+2. THE method SHALL validate that the model has `ResponsesModality`
+3. THE method SHALL throw `BedrockLibraryError.invalidModality` if the model does not support Responses
+4. THE method SHALL construct the request, call the mantle client, and return the parsed response
+5. THE method SHALL log request/response metadata via the service logger
+
+### Requirement 7: Unit Tests
+
+**User Story:** As a developer, I want comprehensive test coverage for the new Responses API surface.
+
+#### Acceptance Criteria
+
+1. Tests SHALL verify model definitions (IDs, modality types, feature checks)
+2. Tests SHALL verify request body serialization to correct JSON format
+3. Tests SHALL verify response body deserialization from sample JSON
+4. Tests SHALL verify end-to-end flow with a mock mantle client
+5. Tests SHALL verify error handling for invalid models and failed requests
+6. Tests SHALL use Swift Testing framework (`@Test`, `#expect`)
+
+### Requirement 8: Example Application
+
+**User Story:** As a developer, I want a working example showing how to use the Responses API with GPT 5.5.
+
+#### Acceptance Criteria
+
+1. THE example SHALL be in `Examples/responses/`
+2. THE example SHALL demonstrate calling GPT 5.5 with an API key
+3. THE example SHALL print the model's text response
+4. THE example SHALL follow the same Package.swift pattern as other examples

--- a/.kiro/specs/openai-responses-api/tasks.md
+++ b/.kiro/specs/openai-responses-api/tasks.md
@@ -1,0 +1,133 @@
+# Implementation Plan: OpenAI Responses API (GPT 5.5 / 5.4)
+
+## Overview
+
+This plan implements support for OpenAI GPT 5.5 and GPT 5.4 models via the Responses API on the `bedrock-mantle` endpoint. Implementation proceeds from foundational types through HTTP client, service integration, tests, and example app.
+
+## Tasks
+
+- [ ] 1. Add AsyncHTTPClient as a direct dependency
+  - [ ] 1.1 Update `Package.swift` to add `async-http-client` package dependency
+    - Add `.package(url: "https://github.com/swift-server/async-http-client.git", from: "1.24.0")`
+    - Add `.product(name: "AsyncHTTPClient", package: "async-http-client")` to BedrockService target dependencies
+    - _Requirements: 4.2_
+
+- [ ] 2. Define ResponsesModality protocol and model types
+  - [ ] 2.1 Create `ResponsesModality` protocol
+    - Create `Sources/BedrockService/BedrockRuntimeClient/Modalities/ResponsesModality.swift`
+    - Define `public protocol ResponsesModality: Modality` with `func getResponsesPath() -> String`
+    - _Requirements: 1.1, 1.2_
+
+  - [ ] 2.2 Create `OpenAIResponses` modality struct
+    - Create `Sources/BedrockService/Models/OpenAI/OpenAIResponses.swift`
+    - Implement `struct OpenAIResponses: ResponsesModality` with stored `responsesPath` property
+    - Implement `getName()` returning `"OpenAI Responses"`
+    - Implement `getResponsesPath()` returning the stored path
+    - _Requirements: 1.3, 1.4_
+
+  - [ ] 2.3 Add model definitions for GPT 5.5 and GPT 5.4
+    - Add to `Sources/BedrockService/Models/OpenAI/OpenAIBedrockModels.swift`:
+      - `.openai_gpt_5_5` with id `"openai.gpt-5.5"`, modality `OpenAIResponses(responsesPath: "/openai/v1/responses")`
+      - `.openai_gpt_5_4` with id `"openai.gpt-5.4"`, modality `OpenAIResponses(responsesPath: "/openai/v1/responses")`
+    - _Requirements: 2.1, 2.2, 2.3, 2.6_
+
+  - [ ] 2.5 Add ResponsesModality conformance to existing OpenAIText
+    - Modify `Sources/BedrockService/Models/OpenAI/OpenAI.swift`:
+      - Add `ResponsesModality` conformance to `OpenAIText` struct
+      - Implement `getResponsesPath()` returning `"/v1/responses"`
+    - This makes existing `.openai_gpt_oss_20b` and `.openai_gpt_oss_120b` usable via `createResponse()`
+    - _Requirements: 2.7, 2.8_
+
+  - [ ] 2.4 Add rawValue lookup and modality checks to BedrockModel
+    - Add cases for both models in `init?(rawValue:)` switch in `Sources/BedrockService/Models/BedrockModel.swift`
+    - Add `hasResponsesModality() -> Bool` method
+    - Add `getResponsesModality() throws -> any ResponsesModality` method
+    - _Requirements: 1.5, 2.4, 2.5_
+
+- [ ] 3. Implement authentication and HTTP client
+  - [ ] 3.1 Create `BedrockMantleAuthentication` enum
+    - Create `Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleAuthentication.swift`
+    - Define `.apiKey(String)` and `.sigV4` cases
+    - Conform to `Sendable`
+    - _Requirements: 3.1, 3.2, 3.3_
+
+  - [ ] 3.2 Create `BedrockMantleClientProtocol`
+    - Create `Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClientProtocol.swift`
+    - Define async method signature for sending requests
+    - _Requirements: 4.1_
+
+  - [ ] 3.3 Implement `BedrockMantleClient`
+    - Create `Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClient.swift`
+    - Use `AsyncHTTPClient.HTTPClient` for POST requests
+    - Build URL from region + model path
+    - Set `Content-Type: application/json`
+    - For `.apiKey`: set `Authorization: Bearer {key}` header
+    - For `.sigV4`: sign request using `AwsCommonRuntimeKit.Signer.signRequest()`
+    - Handle HTTP error responses (4xx/5xx)
+    - _Requirements: 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8_
+
+- [ ] 4. Define request/response types
+  - [ ] 4.1 Create `ResponsesInput`
+    - Create `Sources/BedrockService/BedrockRuntimeClient/Responses/ResponsesInput.swift`
+    - Define `ResponsesRequestBody` with `model`, `input` (messages array), `store` (optional Bool)
+    - Define `ResponsesMessage` with `role` and `content` strings
+    - _Requirements: 5.1, 5.2, 5.5_
+
+  - [ ] 4.2 Create `ResponsesOutput`
+    - Create `Sources/BedrockService/BedrockRuntimeClient/Responses/ResponsesOutput.swift`
+    - Define response struct with `id`, `model`, `output` array, `usage`
+    - Implement text extraction helper (navigate output → message → content → text)
+    - Define `ResponsesUsage` with `inputTokens`, `outputTokens`
+    - _Requirements: 5.3, 5.4, 5.5_
+
+- [ ] 5. Integrate with BedrockService
+  - [ ] 5.1 Create `BedrockService+Responses.swift`
+    - Create `Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockService+Responses.swift`
+    - Implement `createResponse(_:with:authentication:store:) async throws -> ResponsesOutput`
+    - Validate model has `ResponsesModality`, throw if not
+    - Construct request body, call mantle client, parse response
+    - Add trace logging for request/response
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5_
+
+- [ ] 6. Unit tests
+  - [ ] 6.1 Create mock mantle client
+    - Create `Tests/Mock/MockBedrockMantleClient.swift`
+    - Return canned JSON response for valid requests
+
+  - [ ] 6.2 Model definition tests
+    - Create `Tests/Responses/ResponsesModelTests.swift`
+    - Verify model IDs, names, modality types
+    - Verify `hasResponsesModality()` returns true
+    - Verify `hasConverseModality()` returns false
+    - Verify `getResponsesPath()` returns correct path
+    - _Requirements: 7.1_
+
+  - [ ] 6.3 Request serialization tests
+    - Create `Tests/Responses/ResponsesRequestTests.swift`
+    - Verify request body encodes to expected JSON
+    - _Requirements: 7.2_
+
+  - [ ] 6.4 Response deserialization tests
+    - Create `Tests/Responses/ResponsesResponseTests.swift`
+    - Verify parsing of sample response JSON
+    - Verify text extraction from response
+    - _Requirements: 7.3_
+
+  - [ ] 6.5 Service integration tests
+    - Create `Tests/Responses/ResponsesServiceTests.swift`
+    - End-to-end with mock client
+    - Test error for model without responses modality
+    - _Requirements: 7.4, 7.5, 7.6_
+
+- [ ] 7. Example application
+  - [ ] 7.1 Create example package
+    - Create `Examples/responses/Package.swift` following existing example pattern
+    - Create `Examples/responses/Sources/Responses.swift`
+    - Demonstrate calling GPT 5.5 with API key auth
+    - Print text response
+    - _Requirements: 8.1, 8.2, 8.3, 8.4_
+
+- [ ] 8. Verification
+  - [ ] 8.1 Run `swift build` — must pass
+  - [ ] 8.2 Run `swift test` — all tests must pass
+  - [ ] 8.3 Run `swift build` in `Examples/responses/` — must compile

--- a/Examples/responses/Package.swift
+++ b/Examples/responses/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Responses",
+    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18)],
+    products: [
+        .executable(name: "Responses", targets: ["Responses"])
+    ],
+    dependencies: [
+        // for production use, uncomment the following line
+        // .package(url: "https://github.com/build-on-aws/swift-bedrock-library.git", branch: "main"),
+
+        // for local development, use the following line
+        .package(name: "swift-bedrock-library", path: "../.."),
+
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Responses",
+            dependencies: [
+                .product(name: "BedrockService", package: "swift-bedrock-library"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        )
+    ]
+)

--- a/Examples/responses/Sources/Responses.swift
+++ b/Examples/responses/Sources/Responses.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BedrockService
+import Foundation
+import Logging
+
+@main
+struct Main {
+    static func main() async throws {
+        do {
+            try await Main.responses()
+        } catch {
+            print("Error:\n\(error)")
+        }
+    }
+
+    static func responses() async throws {
+        var logger = Logger(label: "Responses")
+        logger.logLevel = .debug
+
+        // Set your Bedrock API key here or via environment variable
+        guard let apiKey = ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] else {
+            print("Error: Set AWS_BEARER_TOKEN_BEDROCK environment variable")
+            print("Create an API key at: https://console.aws.amazon.com/bedrock/home#/api-keys")
+            return
+        }
+
+        let bedrock = try await BedrockService(
+            region: .useast2,
+            logger: logger
+        )
+
+        // GPT 5.5 via the Responses API
+        let reply = try await bedrock.createResponse(
+            "Can you explain the features of Amazon Bedrock?",
+            with: .openai_gpt_5_5,
+            authentication: .apiKey(apiKey),
+            store: false
+        )
+
+        print("Model: \(reply.model.name)")
+        print("Response ID: \(reply.id)")
+        print("Tokens: \(reply.usage.inputTokens) in / \(reply.usage.outputTokens) out")
+        print("\nAssistant: \(reply.text)")
+    }
+}

--- a/Examples/responses/Sources/Responses.swift
+++ b/Examples/responses/Sources/Responses.swift
@@ -31,11 +31,27 @@ struct Main {
         var logger = Logger(label: "Responses")
         logger.logLevel = .debug
 
-        // Set your Bedrock API key here or via environment variable
-        guard let apiKey = ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] else {
-            print("Error: Set AWS_BEARER_TOKEN_BEDROCK environment variable")
-            print("Create an API key at: https://console.aws.amazon.com/bedrock/home#/api-keys")
-            return
+        print("Choose authentication method:")
+        print("  1. API Key (set AWS_BEARER_TOKEN_BEDROCK environment variable)")
+        print("  2. SigV4 (uses default AWS credential provider chain)")
+        print()
+        print("Enter 1 or 2: ", terminator: "")
+
+        let choice = readLine()?.trimmingCharacters(in: .whitespaces) ?? "1"
+
+        let authentication: BedrockAuthentication
+        switch choice {
+        case "2":
+            print("Using SigV4 with default credential provider chain")
+            authentication = .default
+        default:
+            guard let apiKey = ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] else {
+                print("Error: Set AWS_BEARER_TOKEN_BEDROCK environment variable")
+                print("Create an API key at: https://console.aws.amazon.com/bedrock/home#/api-keys")
+                return
+            }
+            print("Using API Key authentication")
+            authentication = .apiKey(key: apiKey)
         }
 
         let bedrock = try await BedrockService(
@@ -43,15 +59,14 @@ struct Main {
             logger: logger
         )
 
-        // GPT 5.5 via the Responses API
         let reply = try await bedrock.createResponse(
             "Can you explain the features of Amazon Bedrock?",
             with: .openai_gpt_5_5,
-            authentication: .apiKey(apiKey),
+            authentication: authentication,
             store: false
         )
 
-        print("Model: \(reply.model.name)")
+        print("\nModel: \(reply.model.name)")
         print("Response ID: \(reply.id)")
         print("Tokens: \(reply.usage.inputTokens) in / \(reply.usage.outputTokens) out")
         print("\nAssistant: \(reply.text)")

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .package(url: "https://github.com/smithy-lang/smithy-swift", from: "0.209.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
         .package(url: "https://github.com/awslabs/aws-crt-swift", from: "0.58.1"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.24.0"),
     ],
     targets: [
         .target(
@@ -28,6 +29,7 @@ let package = Package(
                 .product(name: "Smithy", package: "smithy-swift"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -10,12 +10,12 @@ let package = Package(
         .library(name: "BedrockService", targets: ["BedrockService"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0"),
-        .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.7.0"),
-        .package(url: "https://github.com/smithy-lang/smithy-swift", from: "0.209.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
-        .package(url: "https://github.com/awslabs/aws-crt-swift", from: "0.58.1"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.24.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.8.2"),
+        .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.7.14"),
+        .package(url: "https://github.com/smithy-lang/smithy-swift", from: "0.215.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.13.1"),
+        .package(url: "https://github.com/awslabs/aws-crt-swift", from: "0.61.1"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.34.0"),
     ],
     targets: [
         .target(

--- a/Sources/BedrockService/BedrockRuntimeClient/Modalities/ResponsesModality.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Modalities/ResponsesModality.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public protocol ResponsesModality: Modality {
+    func getResponsesPath() -> String
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleAuthentication.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleAuthentication.swift
@@ -13,7 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SmithyIdentity
+
 public enum BedrockMantleAuthentication: Sendable {
     case apiKey(String)
-    case sigV4
+    case sigV4(any AWSCredentialIdentityResolver)
 }

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleAuthentication.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleAuthentication.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public enum BedrockMantleAuthentication: Sendable {
+    case apiKey(String)
+    case sigV4
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClient.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClient.swift
@@ -63,7 +63,9 @@ public struct BedrockMantleClient: BedrockMantleClientProtocol {
             }
         }
 
-        request.body = .bytes(ByteBuffer(data: body))
+        var buffer = ByteBuffer()
+        buffer.writeBytes(body)
+        request.body = .bytes(buffer)
 
         logger.trace(
             "Sending request to bedrock-mantle",
@@ -73,7 +75,7 @@ public struct BedrockMantleClient: BedrockMantleClientProtocol {
         let response = try await httpClient.execute(request, timeout: .seconds(120))
 
         let responseBody = try await response.body.collect(upTo: 10 * 1024 * 1024)
-        let responseData = Data(buffer: responseBody)
+        let responseData = Data(responseBody.readableBytesView)
 
         guard (200..<300).contains(response.status.code) else {
             let errorMessage = String(data: responseData, encoding: .utf8) ?? "Unknown error"

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClient.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClient.swift
@@ -14,9 +14,12 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+import AwsCommonRuntimeKit
 import Logging
 import NIOCore
 import NIOHTTP1
+import SmithyIdentity
+import SmithyIdentityAPI
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials
@@ -26,11 +29,13 @@ import Foundation
 
 public struct BedrockMantleClient: BedrockMantleClientProtocol {
     private let httpClient: HTTPClient
-    private let logger: Logger
+    private let logger: Logging.Logger
+    private let region: String
 
-    public init(logger: Logger? = nil) {
+    public init(region: String, logger: Logging.Logger? = nil) {
         self.httpClient = HTTPClient.shared
-        self.logger = logger ?? Logger(label: "bedrock.mantle.client")
+        self.region = region
+        self.logger = logger ?? Logging.Logger(label: "bedrock.mantle.client")
     }
 
     public func sendRequest(
@@ -47,10 +52,15 @@ public struct BedrockMantleClient: BedrockMantleClientProtocol {
         switch authentication {
         case .apiKey(let key):
             request.headers.add(name: "Authorization", value: "Bearer \(key)")
-        case .sigV4:
-            throw BedrockLibraryError.notImplemented(
-                "SigV4 authentication for bedrock-mantle is not yet implemented. Use .apiKey() instead."
+        case .sigV4(let credentialResolver):
+            let signedHeaders = try await signWithSigV4(
+                url: url,
+                body: body,
+                credentialResolver: credentialResolver
             )
+            for header in signedHeaders {
+                request.headers.replaceOrAdd(name: header.name, value: header.value)
+            }
         }
 
         request.body = .bytes(ByteBuffer(data: body))
@@ -73,5 +83,49 @@ public struct BedrockMantleClient: BedrockMantleClientProtocol {
         }
 
         return responseData
+    }
+
+    private func signWithSigV4(
+        url: URL,
+        body: Data,
+        credentialResolver: any AWSCredentialIdentityResolver
+    ) async throws -> [HTTPHeader] {
+        let path = url.path
+        let host = url.host ?? "bedrock-mantle.\(region).api.aws"
+
+        let identity = try await credentialResolver.getIdentity()
+
+        let credentials = try Credentials(
+            accessKey: identity.accessKey,
+            secret: identity.secret,
+            sessionToken: identity.sessionToken
+        )
+
+        let headers = [
+            HTTPHeader(name: "Content-Type", value: "application/json"),
+            HTTPHeader(name: "Host", value: host),
+        ]
+
+        let crtRequest = try HTTPRequest(
+            method: "POST",
+            path: path,
+            headers: headers,
+            body: ByteBuffer(data: body)
+        )
+
+        let signingConfig = SigningConfig(
+            algorithm: .signingV4,
+            signatureType: .requestHeaders,
+            service: "bedrock",
+            region: region,
+            credentials: credentials
+        )
+
+        let signedRequest = try await Signer.signRequest(
+            request: crtRequest,
+            config: signingConfig
+        )
+
+        return signedRequest.getHeaders()
     }
 }

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClient.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClient.swift
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AsyncHTTPClient
+import Logging
+import NIOCore
+import NIOHTTP1
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+public struct BedrockMantleClient: BedrockMantleClientProtocol {
+    private let httpClient: HTTPClient
+    private let logger: Logger
+
+    public init(logger: Logger? = nil) {
+        self.httpClient = HTTPClient.shared
+        self.logger = logger ?? Logger(label: "bedrock.mantle.client")
+    }
+
+    public func sendRequest(
+        body: Data,
+        url: URL,
+        authentication: BedrockMantleAuthentication
+    ) async throws -> Data {
+        let urlString = url.absoluteString
+
+        var request = HTTPClientRequest(url: urlString)
+        request.method = .POST
+        request.headers.add(name: "Content-Type", value: "application/json")
+
+        switch authentication {
+        case .apiKey(let key):
+            request.headers.add(name: "Authorization", value: "Bearer \(key)")
+        case .sigV4:
+            throw BedrockLibraryError.notImplemented(
+                "SigV4 authentication for bedrock-mantle is not yet implemented. Use .apiKey() instead."
+            )
+        }
+
+        request.body = .bytes(ByteBuffer(data: body))
+
+        logger.trace(
+            "Sending request to bedrock-mantle",
+            metadata: ["url": .string(urlString)]
+        )
+
+        let response = try await httpClient.execute(request, timeout: .seconds(120))
+
+        let responseBody = try await response.body.collect(upTo: 10 * 1024 * 1024)
+        let responseData = Data(buffer: responseBody)
+
+        guard (200..<300).contains(response.status.code) else {
+            let errorMessage = String(data: responseData, encoding: .utf8) ?? "Unknown error"
+            throw BedrockLibraryError.invalidSDKResponse(
+                "bedrock-mantle returned HTTP \(response.status.code): \(errorMessage)"
+            )
+        }
+
+        return responseData
+    }
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClientProtocol.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockMantleClientProtocol.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+public protocol BedrockMantleClientProtocol: Sendable {
+    func sendRequest(body: Data, url: URL, authentication: BedrockMantleAuthentication) async throws -> Data
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockService+Responses.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockService+Responses.swift
@@ -13,6 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AWSSDKIdentity
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -25,14 +27,16 @@ extension BedrockService {
     /// - Parameters:
     ///   - input: The user message text
     ///   - model: A BedrockModel that supports ResponsesModality
-    ///   - authentication: Authentication method (.apiKey or .sigV4)
+    ///   - authentication: Authentication method — uses the same BedrockAuthentication as the rest of the library.
+    ///     For `.apiKey`, the key is sent as a Bearer token. For all other methods (`.default`, `.profile`, `.sso`, etc.),
+    ///     credentials are resolved and used for SigV4 signing.
     ///   - store: Whether to store the response for multi-turn conversations (default: nil, uses server default)
     ///   - mantleClient: Optional custom client for testing
     /// - Returns: A ResponsesOutput containing the model's text reply and usage info
     public func createResponse(
         _ input: String,
         with model: BedrockModel,
-        authentication: BedrockMantleAuthentication,
+        authentication: BedrockAuthentication,
         store: Bool? = nil,
         mantleClient: BedrockMantleClientProtocol? = nil
     ) async throws -> ResponsesOutput {
@@ -61,11 +65,13 @@ extension BedrockService {
             ]
         )
 
-        let client = mantleClient ?? BedrockMantleClient(logger: self.logger)
+        let mantleAuth = try await resolveMantleAuthentication(authentication)
+
+        let client = mantleClient ?? BedrockMantleClient(region: region.rawValue, logger: self.logger)
         let responseData = try await client.sendRequest(
             body: bodyData,
             url: url,
-            authentication: authentication
+            authentication: mantleAuth
         )
 
         let decoder = JSONDecoder()
@@ -84,5 +90,19 @@ extension BedrockService {
         )
 
         return output
+    }
+
+    private func resolveMantleAuthentication(
+        _ authentication: BedrockAuthentication
+    ) async throws -> BedrockMantleAuthentication {
+        switch authentication {
+        case .apiKey(let key):
+            return .apiKey(key)
+        default:
+            guard let resolver = try await authentication.getAWSCredentialIdentityResolver(logger: logger) else {
+                return .sigV4(DefaultAWSCredentialIdentityResolverChain())
+            }
+            return .sigV4(resolver)
+        }
     }
 }

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockService+Responses.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockService+Responses.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension BedrockService {
+
+    /// Creates a response using the OpenAI Responses API on the bedrock-mantle endpoint.
+    /// - Parameters:
+    ///   - input: The user message text
+    ///   - model: A BedrockModel that supports ResponsesModality
+    ///   - authentication: Authentication method (.apiKey or .sigV4)
+    ///   - store: Whether to store the response for multi-turn conversations (default: nil, uses server default)
+    ///   - mantleClient: Optional custom client for testing
+    /// - Returns: A ResponsesOutput containing the model's text reply and usage info
+    public func createResponse(
+        _ input: String,
+        with model: BedrockModel,
+        authentication: BedrockMantleAuthentication,
+        store: Bool? = nil,
+        mantleClient: BedrockMantleClientProtocol? = nil
+    ) async throws -> ResponsesOutput {
+        let modality = try model.getResponsesModality()
+        let path = modality.getResponsesPath()
+
+        let requestBody = ResponsesRequestBody(
+            model: model,
+            input: [ResponsesMessage(role: .user, content: input)],
+            store: store
+        )
+
+        let encoder = JSONEncoder()
+        let bodyData = try encoder.encode(requestBody)
+
+        let urlString = "https://bedrock-mantle.\(region.rawValue).api.aws\(path)"
+        guard let url = URL(string: urlString, encodingInvalidCharacters: false) else {
+            throw BedrockLibraryError.invalidURI(urlString)
+        }
+
+        logger.trace(
+            "Creating response via bedrock-mantle",
+            metadata: [
+                "model.id": .string(model.id),
+                "url": .string(urlString),
+            ]
+        )
+
+        let client = mantleClient ?? BedrockMantleClient(logger: self.logger)
+        let responseData = try await client.sendRequest(
+            body: bodyData,
+            url: url,
+            authentication: authentication
+        )
+
+        let decoder = JSONDecoder()
+        let rawOutput = try decoder.decode(ResponsesRawOutput.self, from: responseData)
+
+        let output = try ResponsesOutput(from: rawOutput)
+
+        logger.trace(
+            "Received response from bedrock-mantle",
+            metadata: [
+                "model.id": .string(model.id),
+                "response.id": .string(output.id),
+                "usage.inputTokens": .stringConvertible(output.usage.inputTokens),
+                "usage.outputTokens": .stringConvertible(output.usage.outputTokens),
+            ]
+        )
+
+        return output
+    }
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/ResponsesInput.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/ResponsesInput.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+struct ResponsesRequestBody: Codable, Sendable {
+    let model: BedrockModel
+    let input: [ResponsesMessage]
+    let store: Bool?
+
+    init(model: BedrockModel, input: [ResponsesMessage], store: Bool? = nil) {
+        self.model = model
+        self.input = input
+        self.store = store
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(model.id, forKey: .model)
+        try container.encode(input, forKey: .input)
+        try container.encodeIfPresent(store, forKey: .store)
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let modelId = try container.decode(String.self, forKey: .model)
+        guard let model = BedrockModel(rawValue: modelId) else {
+            throw BedrockLibraryError.notFound("Unknown model: \(modelId)")
+        }
+        self.model = model
+        self.input = try container.decode([ResponsesMessage].self, forKey: .input)
+        self.store = try container.decodeIfPresent(Bool.self, forKey: .store)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case input
+        case store
+    }
+}
+
+public struct ResponsesMessage: Codable, Sendable {
+    public let role: Role
+    public let content: String
+
+    public init(role: Role, content: String) {
+        self.role = role
+        self.content = content
+    }
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/ResponsesOutput.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/ResponsesOutput.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+public struct ResponsesOutput: Sendable {
+    public let id: String
+    public let text: String
+    public let model: BedrockModel
+    public let usage: ResponsesUsage
+
+    init(from raw: ResponsesRawOutput) throws {
+        self.id = raw.id
+        guard let model = BedrockModel(rawValue: raw.model) else {
+            throw BedrockLibraryError.notFound("Unknown model in response: \(raw.model)")
+        }
+        self.model = model
+        self.usage = ResponsesUsage(
+            inputTokens: raw.usage.input_tokens,
+            outputTokens: raw.usage.output_tokens
+        )
+        guard let text = raw.extractText() else {
+            throw BedrockLibraryError.completionNotFound(
+                "No text output found in Responses API response"
+            )
+        }
+        self.text = text
+    }
+}
+
+public struct ResponsesUsage: Sendable {
+    public let inputTokens: Int
+    public let outputTokens: Int
+}
+
+struct ResponsesRawOutput: Codable, Sendable {
+    let id: String
+    let object: String
+    let model: String
+    let output: [ResponsesOutputItem]
+    let usage: ResponsesRawUsage
+
+    func extractText() -> String? {
+        for item in output {
+            if item.type == "message", let content = item.content {
+                for block in content {
+                    if block.type == "output_text", let text = block.text {
+                        return text
+                    }
+                }
+            }
+        }
+        return nil
+    }
+}
+
+struct ResponsesOutputItem: Codable, Sendable {
+    let type: String
+    let role: String?
+    let content: [ResponsesContentBlock]?
+}
+
+struct ResponsesContentBlock: Codable, Sendable {
+    let type: String
+    let text: String?
+}
+
+struct ResponsesRawUsage: Codable, Sendable {
+    let input_tokens: Int
+    let output_tokens: Int
+    let total_tokens: Int?
+}

--- a/Sources/BedrockService/BedrockService.swift
+++ b/Sources/BedrockService/BedrockService.swift
@@ -216,11 +216,13 @@ public struct BedrockService: Sendable {
             logger.trace("Using AWS credentials for authentication")
         }
 
-        //We uncheck AWS_BEARER_TOKEN_BEDROCK to avoid conflict with future AWS SDK version
-        //see https://docs.aws.amazon.com/bedroswift buildck/latest/userguide/getting-started-api-keys.html
-        //FIXME: there is a risk of side effect here - what other ways we have to ignore this variable ?
-        unsetenv("AWS_BEARER_TOKEN_BEDROCK")
-        logger.warning("AWS_BEARER_TOKEN_BEDROCK was removed from the environment to prevent conflicts with the AWS SDK. Read this variable before initializing BedrockService if you need its value.")
+        // We unset AWS_BEARER_TOKEN_BEDROCK to avoid conflict with future AWS SDK version
+        // see https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started-api-keys.html
+        // FIXME: there is a risk of side effect here - what other ways we have to ignore this variable ?
+        if ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] != nil {
+            unsetenv("AWS_BEARER_TOKEN_BEDROCK")
+            logger.warning("AWS_BEARER_TOKEN_BEDROCK was removed from the environment to prevent conflicts with the AWS SDK. Read this variable before initializing BedrockService if you need its value.")
+        }
 
         return config
     }

--- a/Sources/BedrockService/BedrockService.swift
+++ b/Sources/BedrockService/BedrockService.swift
@@ -217,9 +217,10 @@ public struct BedrockService: Sendable {
         }
 
         //We uncheck AWS_BEARER_TOKEN_BEDROCK to avoid conflict with future AWS SDK version
-        //see https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started-api-keys.html
+        //see https://docs.aws.amazon.com/bedroswift buildck/latest/userguide/getting-started-api-keys.html
         //FIXME: there is a risk of side effect here - what other ways we have to ignore this variable ?
         unsetenv("AWS_BEARER_TOKEN_BEDROCK")
+        logger.warning("AWS_BEARER_TOKEN_BEDROCK was removed from the environment to prevent conflicts with the AWS SDK. Read this variable before initializing BedrockService if you need its value.")
 
         return config
     }

--- a/Sources/BedrockService/BedrockService.swift
+++ b/Sources/BedrockService/BedrockService.swift
@@ -221,7 +221,9 @@ public struct BedrockService: Sendable {
         // FIXME: there is a risk of side effect here - what other ways we have to ignore this variable ?
         if ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] != nil {
             unsetenv("AWS_BEARER_TOKEN_BEDROCK")
-            logger.warning("AWS_BEARER_TOKEN_BEDROCK was removed from the environment to prevent conflicts with the AWS SDK. Read this variable before initializing BedrockService if you need its value.")
+            logger.warning(
+                "AWS_BEARER_TOKEN_BEDROCK was removed from the environment to prevent conflicts with the AWS SDK. Read this variable before initializing BedrockService if you need its value."
+            )
         }
 
         return config

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -133,6 +133,8 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
         // OpenAI
         case BedrockModel.openai_gpt_oss_20b.id: self = BedrockModel.openai_gpt_oss_20b
         case BedrockModel.openai_gpt_oss_120b.id: self = BedrockModel.openai_gpt_oss_120b
+        case BedrockModel.openai_gpt_5_5.id: self = BedrockModel.openai_gpt_5_5
+        case BedrockModel.openai_gpt_5_4.id: self = BedrockModel.openai_gpt_5_4
         // stability
         case BedrockModel.stable_image_core.id: self = BedrockModel.stable_image_core
         case BedrockModel.stable_image_ultra.id: self = BedrockModel.stable_image_ultra
@@ -268,6 +270,27 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
     /// - Returns: True if the model supports conditioned text to image generation
     public func hasConditionedTextToImageModality() -> Bool {
         modality as? any ConditionedTextToImageModality != nil
+    }
+
+    // MARK - Responses
+
+    /// Checks if the model supports the Responses API (bedrock-mantle)
+    /// - Returns: True if the model supports the Responses API
+    public func hasResponsesModality() -> Bool {
+        modality as? any ResponsesModality != nil
+    }
+
+    /// Checks if the model supports the Responses API and returns ResponsesModality
+    /// - Returns: ResponsesModality if the model supports the Responses API
+    public func getResponsesModality() throws -> any ResponsesModality {
+        guard let responsesModality = modality as? any ResponsesModality else {
+            throw BedrockLibraryError.invalidModality(
+                self,
+                modality,
+                "Model \(id) does not support the Responses API"
+            )
+        }
+        return responsesModality
     }
 
     // MARK - Converse

--- a/Sources/BedrockService/Models/OpenAI/OpenAI.swift
+++ b/Sources/BedrockService/Models/OpenAI/OpenAI.swift
@@ -19,13 +19,14 @@ import FoundationEssentials
 import Foundation
 #endif
 
-struct OpenAIText: TextModality, ConverseModality {
+struct OpenAIText: TextModality, ConverseModality, ResponsesModality {
     let parameters: TextGenerationParameters
     let converseParameters: ConverseParameters
     let converseFeatures: [ConverseFeature]
     let maxReasoningTokens: Parameter<Int>
 
     func getName() -> String { "OpenAI Text Generation" }
+    func getResponsesPath() -> String { "/v1/responses" }
 
     init(
         parameters: TextGenerationParameters,

--- a/Sources/BedrockService/Models/OpenAI/OpenAIBedrockModels.swift
+++ b/Sources/BedrockService/Models/OpenAI/OpenAIBedrockModels.swift
@@ -52,4 +52,14 @@ extension BedrockModel {
             features: [.textGeneration, .systemPrompts, .document]
         )
     )
+    public static let openai_gpt_5_5: BedrockModel = BedrockModel(
+        id: "openai.gpt-5.5",
+        name: "OpenAI GPT 5.5",
+        modality: OpenAIResponses(responsesPath: "/openai/v1/responses")
+    )
+    public static let openai_gpt_5_4: BedrockModel = BedrockModel(
+        id: "openai.gpt-5.4",
+        name: "OpenAI GPT 5.4",
+        modality: OpenAIResponses(responsesPath: "/openai/v1/responses")
+    )
 }

--- a/Sources/BedrockService/Models/OpenAI/OpenAIResponses.swift
+++ b/Sources/BedrockService/Models/OpenAI/OpenAIResponses.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+struct OpenAIResponses: ResponsesModality {
+    let responsesPath: String
+
+    func getName() -> String { "OpenAI Responses" }
+    func getResponsesPath() -> String { responsesPath }
+}

--- a/Tests/Mock/MockBedrockMantleClient.swift
+++ b/Tests/Mock/MockBedrockMantleClient.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BedrockService
+import Foundation
+
+public struct MockBedrockMantleClient: BedrockMantleClientProtocol {
+    public init() {}
+
+    public func sendRequest(
+        body: Data,
+        url: URL,
+        authentication: BedrockMantleAuthentication
+    ) async throws -> Data {
+        guard let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+            let model = json["model"] as? String,
+            let input = json["input"] as? [[String: Any]],
+            let firstMessage = input.first,
+            let content = firstMessage["content"] as? String
+        else {
+            throw BedrockLibraryError.invalidSDKResponse("Invalid request body")
+        }
+
+        let response = """
+            {
+                "id": "resp_mock_123",
+                "object": "response",
+                "model": "\(model)",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Mock response for: \(content)"
+                            }
+                        ]
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 20,
+                    "total_tokens": 30
+                }
+            }
+            """
+        return response.data(using: .utf8)!
+    }
+}

--- a/Tests/Responses/ResponsesModelTests.swift
+++ b/Tests/Responses/ResponsesModelTests.swift
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import BedrockService
+
+@Suite("Responses Model Tests")
+struct ResponsesModelTests {
+
+    @Test("GPT 5.5 has correct model ID")
+    func gpt55ModelId() {
+        #expect(BedrockModel.openai_gpt_5_5.id == "openai.gpt-5.5")
+    }
+
+    @Test("GPT 5.4 has correct model ID")
+    func gpt54ModelId() {
+        #expect(BedrockModel.openai_gpt_5_4.id == "openai.gpt-5.4")
+    }
+
+    @Test("GPT 5.5 has responses modality")
+    func gpt55HasResponsesModality() {
+        #expect(BedrockModel.openai_gpt_5_5.hasResponsesModality())
+    }
+
+    @Test("GPT 5.4 has responses modality")
+    func gpt54HasResponsesModality() {
+        #expect(BedrockModel.openai_gpt_5_4.hasResponsesModality())
+    }
+
+    @Test("GPT 5.5 does not have converse modality")
+    func gpt55NoConverseModality() {
+        #expect(!BedrockModel.openai_gpt_5_5.hasConverseModality())
+    }
+
+    @Test("GPT 5.4 does not have text modality")
+    func gpt54NoTextModality() {
+        #expect(!BedrockModel.openai_gpt_5_4.hasTextModality())
+    }
+
+    @Test("GPT 5.5 uses /openai/v1/responses path")
+    func gpt55ResponsesPath() throws {
+        let modality = try BedrockModel.openai_gpt_5_5.getResponsesModality()
+        #expect(modality.getResponsesPath() == "/openai/v1/responses")
+    }
+
+    @Test("GPT 5.4 uses /openai/v1/responses path")
+    func gpt54ResponsesPath() throws {
+        let modality = try BedrockModel.openai_gpt_5_4.getResponsesModality()
+        #expect(modality.getResponsesPath() == "/openai/v1/responses")
+    }
+
+    @Test("gpt-oss-20b has responses modality")
+    func gptOss20bHasResponsesModality() {
+        #expect(BedrockModel.openai_gpt_oss_20b.hasResponsesModality())
+    }
+
+    @Test("gpt-oss-120b has responses modality")
+    func gptOss120bHasResponsesModality() {
+        #expect(BedrockModel.openai_gpt_oss_120b.hasResponsesModality())
+    }
+
+    @Test("gpt-oss-20b uses /v1/responses path")
+    func gptOss20bResponsesPath() throws {
+        let modality = try BedrockModel.openai_gpt_oss_20b.getResponsesModality()
+        #expect(modality.getResponsesPath() == "/v1/responses")
+    }
+
+    @Test("gpt-oss-20b still has converse modality")
+    func gptOss20bStillHasConverse() {
+        #expect(BedrockModel.openai_gpt_oss_20b.hasConverseModality())
+    }
+
+    @Test("GPT 5.5 is resolvable from rawValue")
+    func gpt55RawValue() {
+        let model = BedrockModel(rawValue: "openai.gpt-5.5")
+        #expect(model != nil)
+        #expect(model?.name == "OpenAI GPT 5.5")
+    }
+
+    @Test("GPT 5.4 is resolvable from rawValue")
+    func gpt54RawValue() {
+        let model = BedrockModel(rawValue: "openai.gpt-5.4")
+        #expect(model != nil)
+        #expect(model?.name == "OpenAI GPT 5.4")
+    }
+}

--- a/Tests/Responses/ResponsesRequestTests.swift
+++ b/Tests/Responses/ResponsesRequestTests.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+@Suite("Responses Request Tests")
+struct ResponsesRequestTests {
+
+    @Test("Request body encodes model and input correctly")
+    func requestBodyEncoding() throws {
+        let request = ResponsesRequestBody(
+            model: .openai_gpt_5_5,
+            input: [ResponsesMessage(role: .user, content: "Hello")]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let data = try encoder.encode(request)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        #expect(json?["model"] as? String == "openai.gpt-5.5")
+        let input = json?["input"] as? [[String: Any]]
+        #expect(input?.count == 1)
+        #expect(input?.first?["role"] as? String == "user")
+        #expect(input?.first?["content"] as? String == "Hello")
+    }
+
+    @Test("Request body omits store when nil")
+    func requestBodyOmitsStoreWhenNil() throws {
+        let request = ResponsesRequestBody(
+            model: .openai_gpt_5_5,
+            input: [ResponsesMessage(role: .user, content: "Hi")],
+            store: nil
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        #expect(json?["store"] == nil)
+    }
+
+    @Test("Request body includes store when set")
+    func requestBodyIncludesStore() throws {
+        let request = ResponsesRequestBody(
+            model: .openai_gpt_5_4,
+            input: [ResponsesMessage(role: .user, content: "Hi")],
+            store: false
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        #expect(json?["store"] as? Bool == false)
+    }
+}

--- a/Tests/Responses/ResponsesResponseTests.swift
+++ b/Tests/Responses/ResponsesResponseTests.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+@Suite("Responses Response Tests")
+struct ResponsesResponseTests {
+
+    let sampleResponse = """
+        {
+            "id": "resp_abc123",
+            "object": "response",
+            "model": "openai.gpt-5.5",
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Hello! I can help you with many things."
+                        }
+                    ]
+                }
+            ],
+            "usage": {
+                "input_tokens": 15,
+                "output_tokens": 42,
+                "total_tokens": 57
+            }
+        }
+        """
+
+    @Test("Parses response correctly")
+    func parseResponse() throws {
+        let data = sampleResponse.data(using: .utf8)!
+        let raw = try JSONDecoder().decode(ResponsesRawOutput.self, from: data)
+        let output = try ResponsesOutput(from: raw)
+
+        #expect(output.id == "resp_abc123")
+        #expect(output.model == .openai_gpt_5_5)
+        #expect(output.text == "Hello! I can help you with many things.")
+        #expect(output.usage.inputTokens == 15)
+        #expect(output.usage.outputTokens == 42)
+    }
+
+    @Test("Extracts text from output blocks")
+    func extractText() throws {
+        let data = sampleResponse.data(using: .utf8)!
+        let raw = try JSONDecoder().decode(ResponsesRawOutput.self, from: data)
+
+        #expect(raw.extractText() == "Hello! I can help you with many things.")
+    }
+
+    @Test("Throws when no text in output")
+    func throwsWhenNoText() throws {
+        let noTextResponse = """
+            {
+                "id": "resp_empty",
+                "object": "response",
+                "model": "openai.gpt-5.5",
+                "output": [],
+                "usage": {
+                    "input_tokens": 5,
+                    "output_tokens": 0,
+                    "total_tokens": 5
+                }
+            }
+            """
+        let data = noTextResponse.data(using: .utf8)!
+        let raw = try JSONDecoder().decode(ResponsesRawOutput.self, from: data)
+
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try ResponsesOutput(from: raw)
+        }
+    }
+}

--- a/Tests/Responses/ResponsesServiceTests.swift
+++ b/Tests/Responses/ResponsesServiceTests.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AwsCommonRuntimeKit
+import Testing
+
+@testable import BedrockService
+
+@Suite("Responses Service Tests")
+struct ResponsesServiceTests {
+    let bedrock: BedrockService
+
+    init() async throws {
+        CommonRuntimeKit.initialize()
+        self.bedrock = try await BedrockService(
+            region: .useast2,
+            bedrockClient: MockBedrockClient(),
+            bedrockRuntimeClient: MockBedrockRuntimeClient()
+        )
+    }
+
+    @Test("createResponse with GPT 5.5 returns text")
+    func createResponseGpt55() async throws {
+        let output = try await bedrock.createResponse(
+            "What is Bedrock?",
+            with: .openai_gpt_5_5,
+            authentication: .apiKey("test-key"),
+            mantleClient: MockBedrockMantleClient()
+        )
+
+        #expect(output.text == "Mock response for: What is Bedrock?")
+        #expect(output.model == .openai_gpt_5_5)
+        #expect(output.id == "resp_mock_123")
+        #expect(output.usage.inputTokens == 10)
+        #expect(output.usage.outputTokens == 20)
+    }
+
+    @Test("createResponse with GPT 5.4 returns text")
+    func createResponseGpt54() async throws {
+        let output = try await bedrock.createResponse(
+            "Hello",
+            with: .openai_gpt_5_4,
+            authentication: .apiKey("test-key"),
+            mantleClient: MockBedrockMantleClient()
+        )
+
+        #expect(output.text == "Mock response for: Hello")
+        #expect(output.model == .openai_gpt_5_4)
+    }
+
+    @Test("createResponse with gpt-oss-20b via Responses API")
+    func createResponseGptOss20b() async throws {
+        let output = try await bedrock.createResponse(
+            "Who are you?",
+            with: .openai_gpt_oss_20b,
+            authentication: .apiKey("test-key"),
+            mantleClient: MockBedrockMantleClient()
+        )
+
+        #expect(output.text == "Mock response for: Who are you?")
+        #expect(output.model == .openai_gpt_oss_20b)
+    }
+
+    @Test("createResponse throws for model without ResponsesModality")
+    func createResponseThrowsForInvalidModel() async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            _ = try await bedrock.createResponse(
+                "Hello",
+                with: .nova_micro,
+                authentication: .apiKey("test-key"),
+                mantleClient: MockBedrockMantleClient()
+            )
+        }
+    }
+}

--- a/Tests/Responses/ResponsesServiceTests.swift
+++ b/Tests/Responses/ResponsesServiceTests.swift
@@ -36,7 +36,7 @@ struct ResponsesServiceTests {
         let output = try await bedrock.createResponse(
             "What is Bedrock?",
             with: .openai_gpt_5_5,
-            authentication: .apiKey("test-key"),
+            authentication: .apiKey(key: "test-key"),
             mantleClient: MockBedrockMantleClient()
         )
 
@@ -52,7 +52,7 @@ struct ResponsesServiceTests {
         let output = try await bedrock.createResponse(
             "Hello",
             with: .openai_gpt_5_4,
-            authentication: .apiKey("test-key"),
+            authentication: .apiKey(key: "test-key"),
             mantleClient: MockBedrockMantleClient()
         )
 
@@ -65,7 +65,7 @@ struct ResponsesServiceTests {
         let output = try await bedrock.createResponse(
             "Who are you?",
             with: .openai_gpt_oss_20b,
-            authentication: .apiKey("test-key"),
+            authentication: .apiKey(key: "test-key"),
             mantleClient: MockBedrockMantleClient()
         )
 
@@ -79,7 +79,7 @@ struct ResponsesServiceTests {
             _ = try await bedrock.createResponse(
                 "Hello",
                 with: .nova_micro,
-                authentication: .apiKey("test-key"),
+                authentication: .apiKey(key: "test-key"),
                 mantleClient: MockBedrockMantleClient()
             )
         }


### PR DESCRIPTION
## Summary
- Add support for the OpenAI Responses API on the `bedrock-mantle` endpoint
- New models: **GPT 5.5** (`openai.gpt-5.5`) and **GPT 5.4** (`openai.gpt-5.4`) — Responses API only
- Existing gpt-oss-20b and gpt-oss-120b models now also support the Responses API (in addition to Invoke/Converse)
- New `BedrockMantleClient` using `AsyncHTTPClient` for HTTP communication
- Dual authentication: API key (Bearer token) and SigV4 (reuses `BedrockAuthentication` — supports `.default`, `.profile`, `.sso`, `.login`, `.webIdentity`, `.static`)
- New `ResponsesModality` protocol with model-specific path routing (`/openai/v1/responses` for GPT 5.5/5.4, `/v1/responses` for gpt-oss)

## Test plan
- [x] `swift build` passes
- [x] `swift test` passes (223 tests, including new Responses suite)
- [x] `Examples/responses` compiles
- [x] Manual test with API key against us-east-2
- [x] Manual test with SigV4 against us-east-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)