### PR TITLE
Add Google Gemma 4 and Gemma 3 model support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,7 +109,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'anthropic-messages', 'api-key', 'converse', 'converse-stream', 'embeddings', 'openai-bedrock', 'openai-responses', 'retrieve', 'stability-image', 'structured-output', 'text_chat' ]"
+      examples: "[ 'anthropic-messages', 'api-key', 'converse', 'converse-stream', 'embeddings', 'google-gemma', 'openai-bedrock', 'openai-responses', 'retrieve', 'stability-image', 'structured-output', 'text_chat' ]"
 
   swift-6-language-mode:
     name: Swift 6 Language Mode

--- a/.kiro/specs/gemma4-model-support/.config.kiro
+++ b/.kiro/specs/gemma4-model-support/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "d9e2136f-fd79-4ee0-b7b2-beda14130e35", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/gemma4-model-support/design.md
+++ b/.kiro/specs/gemma4-model-support/design.md
@@ -1,0 +1,556 @@
+# Design Document: Gemma 4 Model Support
+
+## Overview
+
+This design adds all six Google Gemma models to the Swift Bedrock Library — three Gemma 4 models and three Gemma 3 models. The two generations differ in endpoint support and capabilities:
+
+**Gemma 4 (mantle-only)**:
+- `gemma4_31b` — 30.7B dense, 256K context
+- `gemma4_26b_a4b` — 25.2B total / 3.8B active MoE, 256K context
+- `gemma4_e2b` — 5.1B total / 2.3B effective PLE, 128K context
+
+These support **ChatCompletionsModality** (`/openai/v1/chat/completions`) and **ResponsesModality** (`/openai/v1/responses`) exclusively on bedrock-mantle. They do NOT support InvokeModel or Converse on bedrock-runtime.
+
+**Gemma 3 (dual-endpoint)**:
+- `gemma3_27b_it` — 27B instruction-tuned, 128K context
+- `gemma3_12b_it` — 12B instruction-tuned, 128K context
+- `gemma3_4b_it` — 4B instruction-tuned, 128K context
+
+These support **TextModality** (InvokeModel via bedrock-runtime), **ConverseModality** (Converse API via bedrock-runtime), and **ChatCompletionsModality** (`/v1/chat/completions` via bedrock-mantle). They do NOT support Responses or Messages APIs.
+
+The implementation introduces:
+1. A new `ChatCompletionsModality` protocol (analogous to `MessagesModality` / `ResponsesModality`)
+2. A new `completeChatCompletion` method on `BedrockService`
+3. A new `Sources/BedrockService/Models/Google/` provider directory
+4. Two modality structs: `Gemma4Text` and `Gemma3Text`
+
+The key insight is that Gemma 3 on bedrock-mantle uses path `/v1/chat/completions` (not `/openai/v1/`), while Gemma 4 uses `/openai/v1/chat/completions`. The `ChatCompletionsModality` protocol's `getChatCompletionsPath()` method encodes this difference per model.
+
+## Architecture
+
+### Endpoint Routing
+
+```mermaid
+graph TD
+    subgraph "bedrock-runtime"
+        TM[TextModality] --> CT["completeText()"]
+        CM[ConverseModality] --> CC["converse()"]
+    end
+
+    subgraph "bedrock-mantle"
+        MM[MessagesModality] --> CMM["createMessage()"]
+        RM[ResponsesModality] --> CR["createResponse()"]
+        CCM[ChatCompletionsModality] --> CCC["completeChatCompletion()"]
+    end
+
+    G4[Gemma 4 models] --> CCM
+    G4 --> RM
+    G4 -.->|NOT supported| TM
+    G4 -.->|NOT supported| CM
+
+    G3[Gemma 3 models] --> TM
+    G3 --> CM
+    G3 --> CCM
+    G3 -.->|NOT supported| RM
+    G3 -.->|NOT supported| MM
+```
+
+### Modality Struct Design
+
+```mermaid
+classDiagram
+    class Modality {
+        <<protocol>>
+        +getName() String
+    }
+    class ChatCompletionsModality {
+        <<protocol>>
+        +getChatCompletionsPath() String
+        +getTextGenerationParameters() TextGenerationParameters
+    }
+    class ResponsesModality {
+        <<protocol>>
+        +getResponsesPath() String
+    }
+    class TextModality {
+        <<protocol>>
+        +getParameters() TextGenerationParameters
+        +getTextRequestBody() BedrockBodyCodable
+        +getTextResponseBody() ContainsTextCompletion
+    }
+    class ConverseModality {
+        <<protocol>>
+        +getConverseParameters() ConverseParameters
+        +getConverseFeatures() [ConverseFeature]
+    }
+
+    Modality <|-- ChatCompletionsModality
+    Modality <|-- ResponsesModality
+    Modality <|-- TextModality
+    Modality <|-- ConverseModality
+
+    class Gemma4Text {
+        +parameters: TextGenerationParameters
+        +getName() String
+        +getChatCompletionsPath() String
+        +getResponsesPath() String
+        +getTextGenerationParameters() TextGenerationParameters
+    }
+    class Gemma3Text {
+        +parameters: TextGenerationParameters
+        +converseParameters: ConverseParameters
+        +converseFeatures: [ConverseFeature]
+        +getName() String
+        +getChatCompletionsPath() String
+        +getParameters() TextGenerationParameters
+        +getTextRequestBody() BedrockBodyCodable
+        +getTextResponseBody() ContainsTextCompletion
+        +getConverseParameters() ConverseParameters
+        +getConverseFeatures() [ConverseFeature]
+        +getTextGenerationParameters() TextGenerationParameters
+    }
+
+    ChatCompletionsModality <|.. Gemma4Text
+    ResponsesModality <|.. Gemma4Text
+    ChatCompletionsModality <|.. Gemma3Text
+    TextModality <|.. Gemma3Text
+    ConverseModality <|.. Gemma3Text
+```
+
+### Key Architectural Decisions
+
+1. **New `ChatCompletionsModality` protocol**: Mirrors `MessagesModality` and `ResponsesModality` — provides a path accessor and a parameters accessor. This is the cleanest way to express "this model supports text generation via the Chat Completions endpoint on bedrock-mantle" without conflating it with `TextModality` (which means InvokeModel support).
+
+2. **Two distinct modality structs**: `Gemma4Text` conforms to `ChatCompletionsModality + ResponsesModality`. `Gemma3Text` conforms to `TextModality + ConverseModality + ChatCompletionsModality`. This keeps the protocol conformances accurate — each model only claims capabilities it actually supports.
+
+3. **Gemma 3 reuses OpenAI wire format for InvokeModel**: The Gemma 3 models on bedrock-runtime use the same JSON request/response schema as the existing OpenAI OSS models (`OpenAIRequestBody` / `OpenAIResponseBody`). The `Gemma3Text` struct's `getTextRequestBody()` and `getTextResponseBody()` methods produce the same types.
+
+4. **Path difference encoded in modality**: Gemma 4 returns `/openai/v1/chat/completions` from `getChatCompletionsPath()`, Gemma 3 returns `/v1/chat/completions`. The `completeChatCompletion` method simply concatenates `https://bedrock-mantle.{region}.api.aws` + the path from the modality.
+
+5. **Shared `ChatCompletionsRequestBody` / `ChatCompletionsOutput`**: Both Gemma 4 and Gemma 3 use identical wire format for Chat Completions (same as OpenAI chat completions schema). A single request body type and output type serves both.
+
+6. **New `BedrockModel` modality checks**: `hasChatCompletionsModality()` and `getChatCompletionsModality()` are added to `BedrockModel` following the exact pattern of the existing checks.
+
+## Components and Interfaces
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `Sources/BedrockService/BedrockRuntimeClient/Modalities/ChatCompletionsModality.swift` | `ChatCompletionsModality` protocol definition |
+| `Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/BedrockService+ChatCompletions.swift` | `completeChatCompletion` service method |
+| `Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/ChatCompletionsInput.swift` | `ChatCompletionsRequestBody` type |
+| `Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/ChatCompletionsOutput.swift` | `ChatCompletionsOutput` and raw response types |
+| `Sources/BedrockService/Models/Google/Google.swift` | `Gemma4Text` and `Gemma3Text` modality structs |
+| `Sources/BedrockService/Models/Google/GoogleBedrockModels.swift` | Six `BedrockModel` static constants |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `Sources/BedrockService/Models/BedrockModel.swift` | Add `hasChatCompletionsModality()`, `getChatCompletionsModality()`, and six new cases in `init?(rawValue:)` |
+
+### `ChatCompletionsModality` Protocol
+
+```swift
+// Sources/BedrockService/BedrockRuntimeClient/Modalities/ChatCompletionsModality.swift
+
+public protocol ChatCompletionsModality: Modality {
+    func getChatCompletionsPath() -> String
+    func getTextGenerationParameters() -> TextGenerationParameters
+}
+```
+
+### `Gemma4Text` Struct
+
+```swift
+struct Gemma4Text: ChatCompletionsModality, ResponsesModality {
+    let parameters: TextGenerationParameters
+
+    func getName() -> String { "Gemma 4 Text Generation" }
+    func getChatCompletionsPath() -> String { "/openai/v1/chat/completions" }
+    func getResponsesPath() -> String { "/openai/v1/responses" }
+    func getTextGenerationParameters() -> TextGenerationParameters { parameters }
+}
+```
+
+### `Gemma3Text` Struct
+
+```swift
+struct Gemma3Text: TextModality, ConverseModality, ChatCompletionsModality {
+    let parameters: TextGenerationParameters
+    let converseParameters: ConverseParameters
+    let converseFeatures: [ConverseFeature]
+
+    func getName() -> String { "Gemma 3 Text Generation" }
+    func getChatCompletionsPath() -> String { "/v1/chat/completions" }
+    func getTextGenerationParameters() -> TextGenerationParameters { parameters }
+
+    init(
+        parameters: TextGenerationParameters,
+        features: [ConverseFeature] = [.textGeneration, .vision, .systemPrompts]
+    ) {
+        self.parameters = parameters
+        self.converseFeatures = features
+        self.converseParameters = ConverseParameters(textGenerationParameters: parameters)
+    }
+
+    func getParameters() -> TextGenerationParameters { parameters }
+
+    func getTextRequestBody(
+        prompt: String,
+        maxTokens: Int?,
+        temperature: Double?,
+        topP: Double?,
+        topK: Int?,
+        stopSequences: [String]?,
+        serviceTier: ServiceTier
+    ) throws -> BedrockBodyCodable {
+        guard let maxTokens = maxTokens ?? parameters.maxTokens.defaultValue else {
+            throw BedrockLibraryError.notFound(
+                "No value was given for maxTokens and no default value was found"
+            )
+        }
+        if topP != nil && temperature != nil {
+            throw BedrockLibraryError.notSupported(
+                "Alter either topP or temperature, but not both."
+            )
+        }
+        guard topK == nil else {
+            throw BedrockLibraryError.notSupported(
+                "TopK is not supported for Gemma 3 text completion"
+            )
+        }
+        return OpenAIRequestBody(
+            prompt: prompt,
+            maxTokens: maxTokens,
+            temperature: temperature ?? parameters.temperature.defaultValue,
+            topP: topP ?? parameters.topP.defaultValue,
+            serviceTier: serviceTier
+        )
+    }
+
+    func getTextResponseBody(from data: Data) throws -> ContainsTextCompletion {
+        let decoder = JSONDecoder()
+        return try decoder.decode(OpenAIResponseBody.self, from: data)
+    }
+}
+```
+
+### `BedrockService.completeChatCompletion` Method
+
+```swift
+extension BedrockService {
+    public func completeChatCompletion(
+        _ input: String,
+        with model: BedrockModel,
+        maxTokens: Int? = nil,
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        serviceTier: ServiceTier = .default,
+        authentication: BedrockAuthentication,
+        mantleClient: BedrockMantleClientProtocol? = nil
+    ) async throws -> ChatCompletionsOutput
+}
+```
+
+Method flow:
+1. Call `model.getChatCompletionsModality()` — throws `invalidModality` if not supported
+2. Get parameters via `modality.getTextGenerationParameters()`
+3. Validate: if both topP and temperature are non-nil, throw `notSupported`
+4. Validate: if topK is non-nil, throw `notSupported` (signature doesn't expose topK, keeping it safe)
+5. Validate: temperature/maxTokens/topP ranges via `parameters.validate(...)`
+6. Construct `ChatCompletionsRequestBody` with model ID, messages, maxTokens, temperature/topP, serviceTier
+7. Build URL: `https://bedrock-mantle.{region}.api.aws{modality.getChatCompletionsPath()}`
+8. Resolve authentication via `resolveMantleAuthentication`
+9. Send request via `BedrockMantleClient.sendRequest`
+10. Decode response into `ChatCompletionsRawOutput`, convert to `ChatCompletionsOutput`
+
+### `BedrockModel` Additions
+
+```swift
+// Modality checks
+extension BedrockModel {
+    public func hasChatCompletionsModality() -> Bool {
+        modality as? any ChatCompletionsModality != nil
+    }
+
+    public func getChatCompletionsModality() throws -> any ChatCompletionsModality {
+        guard let chatCompletionsModality = modality as? any ChatCompletionsModality else {
+            throw BedrockLibraryError.invalidModality(
+                self,
+                modality,
+                "Model \(id) does not support the Chat Completions API"
+            )
+        }
+        return chatCompletionsModality
+    }
+}
+
+// init?(rawValue:) additions — six new cases in the switch:
+case BedrockModel.gemma4_31b.id: self = BedrockModel.gemma4_31b
+case BedrockModel.gemma4_26b_a4b.id: self = BedrockModel.gemma4_26b_a4b
+case BedrockModel.gemma4_e2b.id: self = BedrockModel.gemma4_e2b
+case BedrockModel.gemma3_27b_it.id: self = BedrockModel.gemma3_27b_it
+case BedrockModel.gemma3_12b_it.id: self = BedrockModel.gemma3_12b_it
+case BedrockModel.gemma3_4b_it.id: self = BedrockModel.gemma3_4b_it
+```
+
+### Protocol Conformance Summary
+
+| Check | Gemma 4 (all 3) | Gemma 3 (all 3) |
+|-------|-----------------|-----------------|
+| `hasTextModality()` | `false` | `true` |
+| `hasChatCompletionsModality()` | `true` | `true` |
+| `hasResponsesModality()` | `true` | `false` |
+| `hasConverseModality()` | `false` | `true` |
+| `hasMessagesModality()` | `false` | `false` |
+| `hasImageModality()` | `false` | `false` |
+
+## Data Models
+
+### Text Generation Parameters
+
+All six models share identical parameter ranges:
+
+| Parameter | Min | Max | Default | Supported |
+|-----------|-----|-----|---------|-----------|
+| temperature | 0 | 2 | 1 | ✓ |
+| maxTokens | 1 | 8192 | 8192 | ✓ |
+| topP | 0 | 1 | 1 | ✓ |
+| topK | — | — | — | ✗ |
+| stopSequences | — | — | — | ✗ |
+
+Constraints (both InvokeModel and Chat Completions paths):
+- temperature and topP are mutually exclusive — providing both non-nil throws `notSupported`
+- topK is not supported — providing a non-nil value throws `notSupported`
+
+### `ChatCompletionsRequestBody`
+
+```swift
+struct ChatCompletionsRequestBody: Codable, Sendable {
+    let model: String
+    let max_completion_tokens: Int
+    let messages: [ChatCompletionsMessage]
+    let service_tier: String
+    let temperature: Double?
+    let top_p: Double?
+}
+
+struct ChatCompletionsMessage: Codable, Sendable {
+    let role: String
+    let content: String
+}
+```
+
+Serialized JSON sent to bedrock-mantle:
+
+```json
+{
+  "model": "google.gemma-4-31b",
+  "max_completion_tokens": 8192,
+  "messages": [{"role": "user", "content": "Hello"}],
+  "service_tier": "default",
+  "temperature": 1.0
+}
+```
+
+### `ChatCompletionsOutput`
+
+```swift
+public struct ChatCompletionsOutput: Sendable {
+    public let id: String
+    public let text: String
+    public let model: String
+    public let usage: ChatCompletionsUsage
+}
+
+public struct ChatCompletionsUsage: Sendable {
+    public let promptTokens: Int
+    public let completionTokens: Int
+    public let totalTokens: Int
+}
+```
+
+### Raw Response JSON (from bedrock-mantle)
+
+```json
+{
+  "id": "chatcmpl-abc123",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {"content": "Generated text here", "role": "assistant"}
+    }
+  ],
+  "created": 1234567890,
+  "model": "google.gemma-4-31b",
+  "object": "chat.completion",
+  "usage": {"completion_tokens": 42, "prompt_tokens": 10, "total_tokens": 52}
+}
+```
+
+### Model Identifiers
+
+| Model | ID | Name | Chat Completions Path |
+|-------|-----|------|----------------------|
+| Gemma 4 31B | `google.gemma-4-31b` | Gemma 4 31B | `/openai/v1/chat/completions` |
+| Gemma 4 26B-A4B | `google.gemma-4-26b-a4b` | Gemma 4 26B-A4B | `/openai/v1/chat/completions` |
+| Gemma 4 E2B | `google.gemma-4-e2b` | Gemma 4 E2B | `/openai/v1/chat/completions` |
+| Gemma 3 27B IT | `google.gemma-3-27b-it` | Gemma 3 27B IT | `/v1/chat/completions` |
+| Gemma 3 12B IT | `google.gemma-3-12b-it` | Gemma 3 12B IT | `/v1/chat/completions` |
+| Gemma 3 4B IT | `google.gemma-3-4b-it` | Gemma 3 4B IT | `/v1/chat/completions` |
+
+### Gemma 3 InvokeModel Wire Format
+
+Gemma 3 on bedrock-runtime uses the same OpenAI-compatible JSON as the existing `openai_gpt_oss_20b` / `openai_gpt_oss_120b` models:
+
+**Request** (reuses `OpenAIRequestBody`):
+```json
+{
+  "max_completion_tokens": 8192,
+  "messages": [{"role": "user", "content": "Hello"}],
+  "service_tier": "default",
+  "temperature": 1.0
+}
+```
+
+**Response** (reuses `OpenAIResponseBody`):
+```json
+{
+  "id": "chatcmpl-xyz",
+  "choices": [{"finish_reason": "stop", "index": 0, "message": {"content": "...", "role": "assistant"}}],
+  "created": 1234567890,
+  "model": "google.gemma-3-27b-it",
+  "object": "chat.completion",
+  "usage": {"completion_tokens": 100, "prompt_tokens": 50, "total_tokens": 150}
+}
+```
+
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Unknown raw values resolve to nil
+
+*For any* string that does not match any known model ID in the library, `BedrockModel(rawValue:)` SHALL return nil.
+
+**Validates: Requirements 1.6**
+
+### Property 2: Out-of-range parameter values are rejected
+
+*For any* Gemma model (all six) and *for any* numeric value that falls outside the declared parameter range (temperature outside [0, 2], maxTokens outside [1, 8192], topP outside [0, 1]), parameter validation SHALL throw an error indicating the value is out of range.
+
+**Validates: Requirements 7.8, 8.8, 9.5**
+
+### Property 3: Chat Completions request serialization contains required fields
+
+*For any* valid prompt string and *for any* valid parameter combination (maxTokens in [1, 8192], at most one of temperature/topP non-nil), serializing a `ChatCompletionsRequestBody` SHALL produce a JSON object containing the keys `model`, `max_completion_tokens`, `messages`, and `service_tier`.
+
+**Validates: Requirements 10.2, 11.2**
+
+### Property 4: Unsupported parameter combinations throw errors
+
+*For any* Gemma model and *for any* pair of non-nil temperature and topP values, attempting text generation SHALL throw a `notSupported` error. Additionally, *for any* non-nil topK value, attempting text generation SHALL throw a `notSupported` error.
+
+**Validates: Requirements 10.4, 10.5, 11.3, 11.4, 20.4, 20.5**
+
+### Property 5: Chat Completions response parsing preserves content text
+
+*For any* valid Chat Completions JSON response containing a non-empty `choices` array with a random `message.content` string, decoding into `ChatCompletionsOutput` SHALL produce an output whose `text` field equals the original content string.
+
+**Validates: Requirements 12.1, 12.2**
+
+### Property 6: InvokeModel response parsing preserves content text (Gemma 3)
+
+*For any* valid OpenAI-format JSON response containing a non-empty `choices` array with a random `message.content` string, decoding via `getTextResponseBody()` on a Gemma 3 modality SHALL produce a `TextCompletion` whose `completion` field equals the original content string.
+
+**Validates: Requirements 16.5, 20.1, 20.2**
+
+## Error Handling
+
+| Scenario | Error | Message |
+|----------|-------|---------|
+| topK provided (non-nil) for any Gemma model | `BedrockLibraryError.notSupported` | "TopK is not supported for Gemma {3\|4} text completion" |
+| Both temperature and topP provided (non-nil) | `BedrockLibraryError.notSupported` | "Alter either topP or temperature, but not both." |
+| Parameter out of declared range | `BedrockLibraryError.invalidParameter` | Includes parameter name and valid bounds |
+| Empty `choices` array in Chat Completions response | `BedrockLibraryError.completionNotFound` | "No choices available in Chat Completions response" |
+| Empty `choices` array in InvokeModel response (Gemma 3) | `BedrockLibraryError.completionNotFound` | "OpenAIResponseBody: no choices available" |
+| Invalid JSON response from bedrock-mantle | `BedrockLibraryError.invalidSDKResponse` | "bedrock-mantle returned HTTP {code}: {message}" |
+| Invalid JSON response from InvokeModel | Swift `DecodingError` | Standard JSONDecoder error |
+| `getTextModality()` on Gemma 4 | `BedrockLibraryError.invalidModality` | "Model {id} does not support text generation" |
+| `getConverseModality()` on Gemma 4 | `BedrockLibraryError.invalidModality` | "Model {id} does not support text generation" |
+| `getMessagesModality()` on any Gemma model | `BedrockLibraryError.invalidModality` | "Model {id} does not support the Messages API" |
+| `getResponsesModality()` on Gemma 3 | `BedrockLibraryError.invalidModality` | "Model {id} does not support the Responses API" |
+| `getImageModality()` on any Gemma model | `BedrockLibraryError.invalidModality` | "Model {id} does not support image generation" |
+| `getChatCompletionsModality()` on non-conforming model | `BedrockLibraryError.invalidModality` | "Model {id} does not support the Chat Completions API" |
+
+## Testing Strategy
+
+### Test Framework
+
+All tests use Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) as per project conventions. Run with `swift test`.
+
+### Unit Tests (Example-Based)
+
+Organized in:
+- `Tests/ChatCompletions/ChatCompletionsModelTests.swift` — model constants, modality checks, parameter declarations
+- `Tests/ChatCompletions/ChatCompletionsRequestTests.swift` — request body serialization specifics
+- `Tests/ChatCompletions/ChatCompletionsResponseTests.swift` — response parsing, edge cases
+- `Tests/ChatCompletions/ChatCompletionsServiceTests.swift` — service method integration with mocks
+
+Coverage:
+- All 6 model constants (ID, name)
+- All modality presence/absence checks (table from Protocol Conformance Summary)
+- Chat Completions path values (`/openai/v1/chat/completions` vs `/v1/chat/completions`)
+- Responses path value (`/openai/v1/responses`) for Gemma 4
+- Raw value initialization for all 6 models
+- Unknown raw value → nil
+- Error throws for unsupported modality access
+- Default parameter usage in request bodies
+- Empty choices error (Chat Completions)
+- Empty choices error (InvokeModel / OpenAIResponseBody)
+- Invalid JSON error handling
+- URL construction for both Gemma 4 and Gemma 3 endpoints
+- Converse features (textGeneration, vision, systemPrompts) for Gemma 3
+- Service tier default ("default") in request body
+
+### Property-Based Tests
+
+Using Swift Testing's `@Test(..., arguments:)` with generated value arrays (minimum 100 test values per property):
+
+| Property | Test Location | Strategy |
+|----------|--------------|----------|
+| 1: Unknown raw values → nil | `ChatCompletionsModelTests` | Generate 100 random UUID strings, verify all return nil from `BedrockModel(rawValue:)` |
+| 2: Out-of-range rejection | `ChatCompletionsModelTests` | Generate 100 random out-of-range values for temperature (< 0 or > 2), maxTokens (< 1 or > 8192), topP (< 0 or > 1); verify validation throws for each Gemma model |
+| 3: Request serialization keys | `ChatCompletionsRequestTests` | Generate 100 random prompts (1-500 chars) with random valid maxTokens, serialize, verify JSON contains required keys |
+| 4: Unsupported params throw | `ChatCompletionsRequestTests` | Generate 100 random (temperature, topP) pairs both non-nil, verify throws; generate 100 random topK values, verify throws |
+| 5: Response parsing round-trip | `ChatCompletionsResponseTests` | Generate 100 random content strings, embed in valid response JSON template, decode, verify `output.text == original` |
+| 6: InvokeModel response round-trip | `ChatCompletionsResponseTests` | Generate 100 random content strings, embed in OpenAI response JSON, decode via Gemma3Text.getTextResponseBody(), verify `completion == original` |
+
+**Configuration**:
+- Each property test tagged with comment: `// Feature: gemma4-model-support, Property {N}: {description}`
+- Minimum 100 iterations per property
+
+### Integration Tests (with Mocks)
+
+Using `MockBedrockMantleClient` (extended for Chat Completions responses) and `MockBedrockRuntimeClient`:
+
+- `completeChatCompletion` with Gemma 4 model → correct URL, correct response
+- `completeChatCompletion` with Gemma 3 model → correct URL (`/v1/...`), correct response
+- `createResponse` with Gemma 4 model → correct URL, correct response
+- `completeText` with Gemma 3 model → InvokeModel via bedrock-runtime, correct response
+- `completeChatCompletion` with non-conforming model → throws `invalidModality`
+- Authentication resolution for both `.apiKey` and SigV4 paths
+
+### Mock Infrastructure
+
+A new `MockBedrockMantleChatCompletionsClient` (or extension of `MockBedrockMantleClient`) that:
+- Parses the incoming request body to extract the `messages` array
+- Returns a well-formed Chat Completions JSON response with predictable content (e.g., "Mock completion for: {input}")
+- Supports both Gemma 4 and Gemma 3 model IDs
+
+The existing `MockBedrockRuntimeClient` already handles InvokeModel responses in the OpenAI format used by Gemma 3.

--- a/.kiro/specs/gemma4-model-support/requirements.md
+++ b/.kiro/specs/gemma4-model-support/requirements.md
@@ -1,0 +1,291 @@
+# Requirements Document
+
+## Introduction
+
+Add support for all six Google Gemma models to the Swift Bedrock Library. This includes three Gemma 4 models (mantle-only) and three Gemma 3 models (supporting both bedrock-runtime and bedrock-mantle). The implementation introduces a new `ChatCompletionsModality` protocol and `completeChatCompletion` method on `BedrockService`, creates a `Google/` provider directory, and defines model constants for all six variants. Gemma 4 models route exclusively through bedrock-mantle, while Gemma 3 models support the existing `InvokeModel`/`Converse` path via bedrock-runtime as well as Chat Completions via bedrock-mantle.
+
+## Glossary
+
+- **Bedrock_Mantle**: The cross-model inference endpoint (`bedrock-mantle.{region}.api.aws`) used by models that expose OpenAI-compatible APIs
+- **Bedrock_Runtime**: The standard AWS Bedrock Runtime endpoint used for InvokeModel and Converse API calls
+- **Chat_Completions_API**: The OpenAI-compatible chat completions endpoint for text generation via the bedrock-mantle service
+- **Responses_API**: The OpenAI-compatible responses endpoint for generating responses with extended features (reasoning content, tool calling)
+- **ChatCompletionsModality**: A new protocol for models supporting text generation via the Chat Completions API on bedrock-mantle (analogous to MessagesModality and ResponsesModality)
+- **TextModality**: A protocol for models supporting text generation via the InvokeModel API on bedrock-runtime
+- **ConverseModality**: A protocol for models supporting the Converse API on bedrock-runtime
+- **ResponsesModality**: A protocol for models supporting the OpenAI Responses API on bedrock-mantle
+- **MessagesModality**: A protocol for models supporting the Anthropic Messages API on bedrock-mantle
+- **Gemma4_31B**: Google's 30.7-billion parameter dense model with built-in reasoning, native function calling, and multimodal input (text/image), 256K token context window
+- **Gemma4_26B_A4B**: Google's mixture-of-experts model with 25.2B total / 3.8B active parameters, with reasoning, function calling, and multimodal input (text/image), 256K token context window
+- **Gemma4_E2B**: Google's compact PLE model with 5.1B total / 2.3B effective parameters, low-latency, reasoning, function calling, multimodal (text/image/audio/video), 128K token context window
+- **Gemma3_27B_IT**: Google's largest Gemma 3 model with 27B parameters, instruction-tuned, multimodal (text/image), 128K context, 8K max output
+- **Gemma3_12B_IT**: Google's 12B parameter Gemma 3 model, instruction-tuned, multimodal (text/image), 128K context, 8K max output
+- **Gemma3_4B_IT**: Google's compact 4B parameter Gemma 3 model, instruction-tuned, edge deployment, 128K context, 8K max output
+- **BedrockModel**: The central type in the Swift Bedrock Library representing a model with its ID, name, and modality configuration
+- **Modality**: A protocol defining the capabilities of a model (text generation, image, embeddings, responses, messages, chat completions, etc.)
+- **ServiceTier**: The Bedrock service tier (default, priority, flex) controlling throughput and pricing
+- **Mantle_Base_URL_Gemma4**: `https://bedrock-mantle.{region}.api.aws/openai/v1` — the base URL for Gemma 4 models on bedrock-mantle
+- **Mantle_Base_URL_Gemma3**: `https://bedrock-mantle.{region}.api.aws/v1` — the base URL for Gemma 3 models on bedrock-mantle (note: `/v1`, not `/openai/v1`)
+
+## Requirements
+
+### Requirement 1: Model Definition for Gemma 4 31B
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for Google Gemma 4 31B, so that I can reference it when making API calls.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `gemma4_31b` with model ID `"google.gemma-4-31b"`
+2. THE BedrockModel `gemma4_31b` SHALL have the display name `"Gemma 4 31B"`
+3. THE BedrockModel `gemma4_31b` SHALL support ChatCompletionsModality with the path `/openai/v1/chat/completions`
+4. THE BedrockModel `gemma4_31b` SHALL support ResponsesModality with the path `/openai/v1/responses`
+5. WHEN the raw value `"google.gemma-4-31b"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `gemma4_31b` instance
+6. IF a raw value other than any known model ID is provided to `BedrockModel(rawValue:)`, THEN THE BedrockModel initializer SHALL return nil
+
+### Requirement 2: Model Definition for Gemma 4 26B-A4B
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for Google Gemma 4 26B-A4B, so that I can reference it when making API calls.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `gemma4_26b_a4b` with model ID `"google.gemma-4-26b-a4b"` and display name `"Gemma 4 26B-A4B"`
+2. THE BedrockModel `gemma4_26b_a4b` SHALL support ChatCompletionsModality with the path `/openai/v1/chat/completions`
+3. THE BedrockModel `gemma4_26b_a4b` SHALL support ResponsesModality with the path `/openai/v1/responses`
+4. WHEN the raw value `"google.gemma-4-26b-a4b"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `gemma4_26b_a4b` instance
+
+### Requirement 3: Model Definition for Gemma 4 E2B
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for Google Gemma 4 E2B, so that I can reference it when making API calls.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `gemma4_e2b` with model ID `"google.gemma-4-e2b"` and display name `"Gemma 4 E2B"`
+2. THE BedrockModel `gemma4_e2b` SHALL support ChatCompletionsModality with the path `/openai/v1/chat/completions`
+3. THE BedrockModel `gemma4_e2b` SHALL support ResponsesModality with the path `/openai/v1/responses`
+4. WHEN the raw value `"google.gemma-4-e2b"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `gemma4_e2b` instance
+
+### Requirement 4: Model Definition for Gemma 3 27B IT
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for Google Gemma 3 27B IT, so that I can reference it when making API calls via InvokeModel, Converse, or Chat Completions.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `gemma3_27b_it` with model ID `"google.gemma-3-27b-it"` and display name `"Gemma 3 27B IT"`
+2. THE BedrockModel `gemma3_27b_it` SHALL support TextModality for InvokeModel via bedrock-runtime
+3. THE BedrockModel `gemma3_27b_it` SHALL support ConverseModality for the Converse API via bedrock-runtime
+4. THE BedrockModel `gemma3_27b_it` SHALL support ChatCompletionsModality with the path `/v1/chat/completions`
+5. WHEN the raw value `"google.gemma-3-27b-it"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `gemma3_27b_it` instance
+
+### Requirement 5: Model Definition for Gemma 3 12B IT
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for Google Gemma 3 12B IT, so that I can reference it when making API calls via InvokeModel, Converse, or Chat Completions.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `gemma3_12b_it` with model ID `"google.gemma-3-12b-it"` and display name `"Gemma 3 12B IT"`
+2. THE BedrockModel `gemma3_12b_it` SHALL support TextModality for InvokeModel via bedrock-runtime
+3. THE BedrockModel `gemma3_12b_it` SHALL support ConverseModality for the Converse API via bedrock-runtime
+4. THE BedrockModel `gemma3_12b_it` SHALL support ChatCompletionsModality with the path `/v1/chat/completions`
+5. WHEN the raw value `"google.gemma-3-12b-it"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `gemma3_12b_it` instance
+
+### Requirement 6: Model Definition for Gemma 3 4B IT
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for Google Gemma 3 4B IT, so that I can reference it when making API calls via InvokeModel, Converse, or Chat Completions.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `gemma3_4b_it` with model ID `"google.gemma-3-4b-it"` and display name `"Gemma 3 4B IT"`
+2. THE BedrockModel `gemma3_4b_it` SHALL support TextModality for InvokeModel via bedrock-runtime
+3. THE BedrockModel `gemma3_4b_it` SHALL support ConverseModality for the Converse API via bedrock-runtime
+4. THE BedrockModel `gemma3_4b_it` SHALL support ChatCompletionsModality with the path `/v1/chat/completions`
+5. WHEN the raw value `"google.gemma-3-4b-it"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `gemma3_4b_it` instance
+
+### Requirement 7: Gemma 4 Text Generation Parameters
+
+**User Story:** As a developer, I want the Gemma 4 models to expose appropriate text generation parameters, so that I can control inference behavior.
+
+#### Acceptance Criteria
+
+1. THE Gemma4_31B model SHALL support the temperature parameter with a minimum value of 0, maximum value of 2, and default value of 1
+2. THE Gemma4_31B model SHALL support the maxTokens parameter with a minimum value of 1, maximum value of 8192, and default value of 8192
+3. THE Gemma4_31B model SHALL support the topP parameter with a minimum value of 0, maximum value of 1, and default value of 1
+4. THE Gemma4_31B model SHALL mark the topK parameter as not supported
+5. THE Gemma4_26B_A4B model SHALL support the same temperature, maxTokens, and topP parameter ranges and defaults as Gemma4_31B, and SHALL mark topK as not supported
+6. THE Gemma4_E2B model SHALL support the same temperature, maxTokens, and topP parameter ranges and defaults as Gemma4_31B, and SHALL mark topK as not supported
+7. THE Gemma4 models SHALL mark the stopSequences parameter as not supported
+8. IF a temperature, maxTokens, or topP value outside the supported range is provided to a Gemma4 model, THEN THE Library SHALL throw an error indicating the value is out of range
+9. WHEN no temperature, maxTokens, or topP value is provided in a Gemma4 text generation request, THE Library SHALL use the parameter's default value
+
+### Requirement 8: Gemma 3 Text Generation Parameters
+
+**User Story:** As a developer, I want the Gemma 3 models to expose appropriate text generation parameters, so that I can control inference behavior via InvokeModel or Chat Completions.
+
+#### Acceptance Criteria
+
+1. THE Gemma3_27B_IT model SHALL support the temperature parameter with a minimum value of 0, maximum value of 2, and default value of 1
+2. THE Gemma3_27B_IT model SHALL support the maxTokens parameter with a minimum value of 1, maximum value of 8192, and default value of 8192
+3. THE Gemma3_27B_IT model SHALL support the topP parameter with a minimum value of 0, maximum value of 1, and default value of 1
+4. THE Gemma3_27B_IT model SHALL mark the topK parameter as not supported
+5. THE Gemma3_12B_IT model SHALL support the same temperature, maxTokens, and topP parameter ranges and defaults as Gemma3_27B_IT, and SHALL mark topK as not supported
+6. THE Gemma3_4B_IT model SHALL support the same temperature, maxTokens, and topP parameter ranges and defaults as Gemma3_27B_IT, and SHALL mark topK as not supported
+7. THE Gemma3 models SHALL mark the stopSequences parameter as not supported
+8. IF a temperature, maxTokens, or topP value outside the supported range is provided to a Gemma3 model, THEN THE Library SHALL throw an error indicating the value is out of range
+9. WHEN no temperature, maxTokens, or topP value is provided in a Gemma3 text generation request, THE Library SHALL use the parameter's default value
+
+### Requirement 9: ChatCompletionsModality Protocol and Service Method
+
+**User Story:** As a developer, I want a `ChatCompletionsModality` protocol and a `completeChatCompletion` method on `BedrockService`, so that models using the Chat Completions API on bedrock-mantle have a clean, consistent interface.
+
+#### Acceptance Criteria
+
+1. THE Library SHALL define a `ChatCompletionsModality` protocol extending `Modality` with a `getChatCompletionsPath() -> String` method and a `getTextGenerationParameters() -> TextGenerationParameters` method
+2. THE BedrockModel SHALL expose `hasChatCompletionsModality() -> Bool` and `getChatCompletionsModality() throws -> any ChatCompletionsModality` methods
+3. WHEN `hasChatCompletionsModality()` is called on a model conforming to ChatCompletionsModality, THE method SHALL return true
+4. IF `getChatCompletionsModality()` is called on a model that does not conform to ChatCompletionsModality, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+5. WHEN `completeChatCompletion` is called, THE Library SHALL validate parameters against the model's declared ranges before sending the request
+6. WHEN `completeChatCompletion` is called, THE Library SHALL support both API key and SigV4 authentication via the `BedrockAuthentication` parameter
+
+### Requirement 10: Chat Completions Request Body for Gemma 4 Models
+
+**User Story:** As a developer, I want the Gemma 4 models to format requests using the OpenAI Chat Completions format routed through bedrock-mantle, so that inference requests are correctly structured.
+
+#### Acceptance Criteria
+
+1. WHEN a text generation request is made with a Gemma 4 model via `completeChatCompletion`, THE Library SHALL send the request to `https://bedrock-mantle.{region}.api.aws/openai/v1/chat/completions` where `{region}` is the region configured on the BedrockService instance
+2. WHEN a text generation request is made with a Gemma 4 model via `completeChatCompletion`, THE Library SHALL format the request body as a JSON object containing `model` (string), `max_completion_tokens` (integer), `messages` (array of objects each with `role` and `content` string fields), `service_tier` (string), and optionally `temperature` (double) and `top_p` (double) fields
+3. WHEN a text generation request is made with a Gemma 4 model and no service tier is specified by the caller, THE Library SHALL include the `service_tier` field in the request body with the value `"default"`
+4. IF both topP and temperature are provided (non-nil) for a Gemma 4 model request, THEN THE Library SHALL throw a `notSupported` error indicating that only one of topP or temperature may be altered at a time
+5. IF a topK value is provided (non-nil) for a Gemma 4 model request, THEN THE Library SHALL throw a `notSupported` error indicating that topK is not supported
+
+### Requirement 11: Chat Completions Request Body for Gemma 3 Models
+
+**User Story:** As a developer, I want the Gemma 3 models to also support chat completions via bedrock-mantle, so that I have a consistent interface alongside InvokeModel.
+
+#### Acceptance Criteria
+
+1. WHEN a text generation request is made with a Gemma 3 model via `completeChatCompletion`, THE Library SHALL send the request to `https://bedrock-mantle.{region}.api.aws/v1/chat/completions` where `{region}` is the region configured on the BedrockService instance
+2. WHEN a text generation request is made with a Gemma 3 model via `completeChatCompletion`, THE Library SHALL format the request body as a JSON object containing `model` (string), `max_completion_tokens` (integer), `messages` (array), `service_tier` (string), and optionally `temperature` (double) and `top_p` (double) fields
+3. IF both topP and temperature are provided (non-nil) for a Gemma 3 model chat completions request, THEN THE Library SHALL throw a `notSupported` error indicating that only one of topP or temperature may be altered at a time
+4. IF a topK value is provided (non-nil) for a Gemma 3 model chat completions request, THEN THE Library SHALL throw a `notSupported` error indicating that topK is not supported
+
+### Requirement 12: Chat Completions Response Parsing
+
+**User Story:** As a developer, I want responses from Chat Completions to be parsed into a `ChatCompletionsOutput` type, so that I can use them consistently regardless of which Gemma model I use.
+
+#### Acceptance Criteria
+
+1. WHEN a successful response is received from a Gemma model via Chat Completions on bedrock-mantle, THE Library SHALL decode the response JSON body expecting top-level fields `id`, `choices`, `created`, `model`, `object`, and `usage`
+2. WHEN a successful response is decoded, THE Library SHALL extract the text string from the first element of the `choices` array's `message.content` field and return it in a `ChatCompletionsOutput` instance
+3. IF the decoded response contains an empty `choices` array, THEN THE Library SHALL throw a `BedrockLibraryError.completionNotFound` error with a descriptive message indicating no choices were available
+4. IF the response body cannot be decoded as valid JSON conforming to the expected format, THEN THE Library SHALL throw a decoding error
+
+### Requirement 13: Responses API Support for Gemma 4 Models
+
+**User Story:** As a developer, I want the Gemma 4 models to support the OpenAI Responses API, so that I can use the `createResponse` method with extended features like reasoning.
+
+#### Acceptance Criteria
+
+1. THE Gemma4_31B model SHALL report `hasResponsesModality()` as true
+2. THE Gemma4_26B_A4B model SHALL report `hasResponsesModality()` as true
+3. THE Gemma4_E2B model SHALL report `hasResponsesModality()` as true
+4. WHEN `getResponsesModality()` is called on any Gemma 4 model, THE Library SHALL return a modality whose `getResponsesPath()` returns `/openai/v1/responses`
+5. WHEN `createResponse` is called with a Gemma 4 model, THE Library SHALL send the request to `https://bedrock-mantle.{region}.api.aws/openai/v1/responses` where `{region}` is the region configured on the BedrockService instance
+
+### Requirement 14: Unsupported Modalities for Gemma 4 Models
+
+**User Story:** As a developer, I want clear errors when attempting to use Gemma 4 models with unsupported API patterns, so that I understand which APIs are available.
+
+#### Acceptance Criteria
+
+1. THE Gemma4_31B model SHALL report `hasTextModality()` as false
+2. THE Gemma4_26B_A4B model SHALL report `hasTextModality()` as false
+3. THE Gemma4_E2B model SHALL report `hasTextModality()` as false
+4. THE Gemma4_31B model SHALL report `hasConverseModality()` as false
+5. THE Gemma4_26B_A4B model SHALL report `hasConverseModality()` as false
+6. THE Gemma4_E2B model SHALL report `hasConverseModality()` as false
+7. THE Gemma4_31B model SHALL report `hasMessagesModality()` as false
+8. THE Gemma4_26B_A4B model SHALL report `hasMessagesModality()` as false
+9. THE Gemma4_E2B model SHALL report `hasMessagesModality()` as false
+10. THE Gemma4_31B model SHALL report `hasImageModality()` as false
+11. THE Gemma4_26B_A4B model SHALL report `hasImageModality()` as false
+12. THE Gemma4_E2B model SHALL report `hasImageModality()` as false
+13. IF `getTextModality()` is called on a Gemma 4 model, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+14. IF `getConverseModality()` is called on a Gemma 4 model, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+15. IF `getMessagesModality()` is called on a Gemma 4 model, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+
+### Requirement 15: Unsupported Modalities for Gemma 3 Models
+
+**User Story:** As a developer, I want clear indication that Gemma 3 models do not support Responses or Messages APIs, so that I use the correct API paths.
+
+#### Acceptance Criteria
+
+1. THE Gemma3_27B_IT model SHALL report `hasResponsesModality()` as false
+2. THE Gemma3_12B_IT model SHALL report `hasResponsesModality()` as false
+3. THE Gemma3_4B_IT model SHALL report `hasResponsesModality()` as false
+4. THE Gemma3_27B_IT model SHALL report `hasMessagesModality()` as false
+5. THE Gemma3_12B_IT model SHALL report `hasMessagesModality()` as false
+6. THE Gemma3_4B_IT model SHALL report `hasMessagesModality()` as false
+7. THE Gemma3_27B_IT model SHALL report `hasImageModality()` as false
+8. THE Gemma3_12B_IT model SHALL report `hasImageModality()` as false
+9. THE Gemma3_4B_IT model SHALL report `hasImageModality()` as false
+10. IF `getResponsesModality()` is called on a Gemma 3 model, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+11. IF `getMessagesModality()` is called on a Gemma 3 model, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+
+### Requirement 16: Gemma 3 InvokeModel Support
+
+**User Story:** As a developer, I want to use Gemma 3 models with the existing `completeText` method via bedrock-runtime InvokeModel, so that I can use them with the standard text generation flow.
+
+#### Acceptance Criteria
+
+1. THE Gemma3_27B_IT model SHALL report `hasTextModality()` as true
+2. THE Gemma3_12B_IT model SHALL report `hasTextModality()` as true
+3. THE Gemma3_4B_IT model SHALL report `hasTextModality()` as true
+4. WHEN `completeText` is called with a Gemma 3 model, THE Library SHALL format the request body for InvokeModel with the appropriate fields and send it via bedrock-runtime
+5. WHEN a response is received from InvokeModel for a Gemma 3 model, THE Library SHALL decode the response and return a `TextCompletion` containing the generated text
+
+### Requirement 17: Gemma 3 Converse API Support
+
+**User Story:** As a developer, I want to use Gemma 3 models with the Converse API, so that I can have multi-turn conversations using the standard Converse interface.
+
+#### Acceptance Criteria
+
+1. THE Gemma3_27B_IT model SHALL report `hasConverseModality()` as true
+2. THE Gemma3_12B_IT model SHALL report `hasConverseModality()` as true
+3. THE Gemma3_4B_IT model SHALL report `hasConverseModality()` as true
+4. THE Gemma3_27B_IT model SHALL support the converse features: textGeneration, vision, and systemPrompts
+5. THE Gemma3_12B_IT model SHALL support the converse features: textGeneration, vision, and systemPrompts
+6. THE Gemma3_4B_IT model SHALL support the converse features: textGeneration, vision, and systemPrompts
+
+### Requirement 18: Mantle Base URL Routing
+
+**User Story:** As a developer, I want the library to route Gemma 4 and Gemma 3 models to their correct bedrock-mantle base URLs, so that API calls reach the correct endpoint.
+
+#### Acceptance Criteria
+
+1. WHEN `completeChatCompletion` is called with a Gemma 4 model, THE Library SHALL construct the URL using the base `https://bedrock-mantle.{region}.api.aws` concatenated with the model's chat completions path `/openai/v1/chat/completions`
+2. WHEN `completeChatCompletion` is called with a Gemma 3 model, THE Library SHALL construct the URL using the base `https://bedrock-mantle.{region}.api.aws` concatenated with the model's chat completions path `/v1/chat/completions`
+3. WHEN `createResponse` is called with a Gemma 4 model, THE Library SHALL construct the URL using the base `https://bedrock-mantle.{region}.api.aws` concatenated with the model's responses path `/openai/v1/responses`
+
+### Requirement 19: Source File Organization
+
+**User Story:** As a contributor to the Swift Bedrock Library, I want Google Gemma model source files organized in a dedicated Google directory, so that the codebase remains consistent with the existing model provider structure.
+
+#### Acceptance Criteria
+
+1. THE Library SHALL contain a `Sources/BedrockService/Models/Google/` directory for Google Gemma model files
+2. THE Library SHALL contain a `GoogleBedrockModels.swift` file in the Google directory defining all six model static constants (`gemma4_31b`, `gemma4_26b_a4b`, `gemma4_e2b`, `gemma3_27b_it`, `gemma3_12b_it`, `gemma3_4b_it`) as extensions on `BedrockModel`
+3. THE Library SHALL contain a `Google.swift` file in the Google directory defining the Gemma 4 modality struct conforming to `ChatCompletionsModality` and `ResponsesModality` protocols
+4. THE Library SHALL contain a `Google.swift` file in the Google directory defining the Gemma 3 modality struct conforming to `TextModality`, `ConverseModality`, and `ChatCompletionsModality` protocols
+5. THE `Google.swift` file SHALL follow the same structural pattern as existing provider modality files (e.g., `DeepSeek.swift`, `OpenAI.swift`)
+
+### Requirement 20: Gemma 3 InvokeModel Request and Response Format
+
+**User Story:** As a developer, I want the Gemma 3 models to format InvokeModel requests and parse responses correctly, so that text generation works through the bedrock-runtime endpoint.
+
+#### Acceptance Criteria
+
+1. WHEN `completeText` is called with a Gemma 3 model, THE Library SHALL format the request body as a JSON object compatible with the model's expected input schema containing the prompt, max tokens, temperature, and top_p fields
+2. WHEN a response is received from InvokeModel for a Gemma 3 model, THE Library SHALL decode the JSON response body and extract the generated text into a `TextCompletion` instance
+3. IF the response body cannot be decoded as valid JSON conforming to the expected format, THEN THE Library SHALL throw a decoding error
+4. IF both topP and temperature are provided (non-nil) for a Gemma 3 InvokeModel request, THEN THE Library SHALL throw a `notSupported` error indicating that only one of topP or temperature may be altered at a time
+5. IF a topK value is provided (non-nil) for a Gemma 3 InvokeModel request, THEN THE Library SHALL throw a `notSupported` error indicating that topK is not supported

--- a/.kiro/specs/gemma4-model-support/tasks.md
+++ b/.kiro/specs/gemma4-model-support/tasks.md
@@ -1,0 +1,247 @@
+# Implementation Plan: Gemma 4 Model Support
+
+## Overview
+
+Add all six Google Gemma models to the Swift Bedrock Library by introducing a new `ChatCompletionsModality` protocol, creating a `Google/` provider directory with `Gemma4Text` and `Gemma3Text` modality structs, adding the `completeChatCompletion` service method, and defining model constants with `rawValue` resolution. The implementation follows existing patterns established by OpenAI, DeepSeek, and Claude models.
+
+## Tasks
+
+- [x] 1. Define ChatCompletionsModality protocol and BedrockModel extensions
+  - [x] 1.1 Create `ChatCompletionsModality` protocol in `Sources/BedrockService/BedrockRuntimeClient/Modalities/ChatCompletionsModality.swift`
+    - Define `ChatCompletionsModality` extending `Modality` with `getChatCompletionsPath() -> String` and `getTextGenerationParameters() -> TextGenerationParameters` methods
+    - Follow the same minimal pattern as `ResponsesModality.swift`
+    - _Requirements: 9.1_
+
+  - [x] 1.2 Add `hasChatCompletionsModality()` and `getChatCompletionsModality()` methods to `BedrockModel` in `Sources/BedrockService/Models/BedrockModel.swift`
+    - Add `hasChatCompletionsModality() -> Bool` using protocol cast pattern
+    - Add `getChatCompletionsModality() throws -> any ChatCompletionsModality` with `invalidModality` error on failure
+    - Follow the exact pattern of existing `hasResponsesModality()` / `getResponsesModality()`
+    - _Requirements: 9.2, 9.3, 9.4_
+
+- [x] 2. Create Google provider directory and modality structs
+  - [x] 2.1 Create `Sources/BedrockService/Models/Google/Google.swift` with `Gemma4Text` and `Gemma3Text` structs
+    - `Gemma4Text` conforms to `ChatCompletionsModality` and `ResponsesModality`
+    - `Gemma4Text.getChatCompletionsPath()` returns `/openai/v1/chat/completions`
+    - `Gemma4Text.getResponsesPath()` returns `/openai/v1/responses`
+    - `Gemma3Text` conforms to `TextModality`, `ConverseModality`, and `ChatCompletionsModality`
+    - `Gemma3Text.getChatCompletionsPath()` returns `/v1/chat/completions`
+    - `Gemma3Text.getTextRequestBody()` creates `OpenAIRequestBody` with topK/topP+temperature validation
+    - `Gemma3Text.getTextResponseBody()` decodes `OpenAIResponseBody`
+    - `Gemma3Text` supports converse features: `.textGeneration`, `.vision`, `.systemPrompts`
+    - Follow the structural pattern of `DeepSeek.swift` and `OpenAI.swift`
+    - _Requirements: 7.1–7.9, 8.1–8.9, 13.4, 14.1–15.11, 16.1–16.3, 17.1–17.6, 19.3, 19.4, 19.5, 20.1–20.5_
+
+  - [x] 2.2 Create `Sources/BedrockService/Models/Google/GoogleBedrockModels.swift` with six model static constants
+    - Define `gemma4_31b` (id: `google.gemma-4-31b`, name: `Gemma 4 31B`, modality: `Gemma4Text`)
+    - Define `gemma4_26b_a4b` (id: `google.gemma-4-26b-a4b`, name: `Gemma 4 26B-A4B`, modality: `Gemma4Text`)
+    - Define `gemma4_e2b` (id: `google.gemma-4-e2b`, name: `Gemma 4 E2B`, modality: `Gemma4Text`)
+    - Define `gemma3_27b_it` (id: `google.gemma-3-27b-it`, name: `Gemma 3 27B IT`, modality: `Gemma3Text`)
+    - Define `gemma3_12b_it` (id: `google.gemma-3-12b-it`, name: `Gemma 3 12B IT`, modality: `Gemma3Text`)
+    - Define `gemma3_4b_it` (id: `google.gemma-3-4b-it`, name: `Gemma 3 4B IT`, modality: `Gemma3Text`)
+    - All models use temperature [0, 2] default 1, maxTokens [1, 8192] default 8192, topP [0, 1] default 1, topK not supported, stopSequences not supported
+    - Follow the pattern of `OpenAIBedrockModels.swift`
+    - _Requirements: 1.1–1.5, 2.1–2.4, 3.1–3.4, 4.1–4.5, 5.1–5.5, 6.1–6.5, 19.1, 19.2_
+
+  - [x] 2.3 Add six new cases to `BedrockModel.init?(rawValue:)` in `Sources/BedrockService/Models/BedrockModel.swift`
+    - Add `case BedrockModel.gemma4_31b.id: self = BedrockModel.gemma4_31b`
+    - Add `case BedrockModel.gemma4_26b_a4b.id: self = BedrockModel.gemma4_26b_a4b`
+    - Add `case BedrockModel.gemma4_e2b.id: self = BedrockModel.gemma4_e2b`
+    - Add `case BedrockModel.gemma3_27b_it.id: self = BedrockModel.gemma3_27b_it`
+    - Add `case BedrockModel.gemma3_12b_it.id: self = BedrockModel.gemma3_12b_it`
+    - Add `case BedrockModel.gemma3_4b_it.id: self = BedrockModel.gemma3_4b_it`
+    - _Requirements: 1.5, 1.6, 2.4, 3.4, 4.5, 5.5, 6.5_
+
+- [x] 3. Create Chat Completions request and response types
+  - [x] 3.1 Create `Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/ChatCompletionsInput.swift`
+    - Define `ChatCompletionsRequestBody` as a `Codable, Sendable` struct with fields: `model` (String), `max_completion_tokens` (Int), `messages` ([ChatCompletionsMessage]), `service_tier` (String), `temperature` (Double?), `top_p` (Double?)
+    - Define `ChatCompletionsMessage` struct with `role` (String) and `content` (String)
+    - Use snake_case coding keys matching the JSON wire format
+    - _Requirements: 10.2, 10.3, 11.2_
+
+  - [x] 3.2 Create `Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/ChatCompletionsOutput.swift`
+    - Define `ChatCompletionsOutput` as a public `Sendable` struct with `id`, `text`, `model`, `usage` (ChatCompletionsUsage)
+    - Define `ChatCompletionsUsage` with `promptTokens`, `completionTokens`, `totalTokens`
+    - Define private `ChatCompletionsRawOutput` Codable struct matching the raw JSON response fields (`id`, `choices`, `created`, `model`, `object`, `usage`)
+    - Implement conversion from `ChatCompletionsRawOutput` to `ChatCompletionsOutput` that throws `completionNotFound` if `choices` is empty
+    - _Requirements: 12.1, 12.2, 12.3, 12.4_
+
+- [x] 4. Implement the `completeChatCompletion` service method
+  - [x] 4.1 Create `Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/BedrockService+ChatCompletions.swift`
+    - Implement `public func completeChatCompletion(_:with:maxTokens:temperature:topP:serviceTier:authentication:mantleClient:) async throws -> ChatCompletionsOutput`
+    - Call `model.getChatCompletionsModality()` to get the modality (throws `invalidModality` if not supported)
+    - Validate: both topP and temperature non-nil → throw `notSupported`
+    - Validate parameter ranges via `TextGenerationParameters`
+    - Build `ChatCompletionsRequestBody` with model ID, messages, resolved maxTokens, optional temperature/topP, service tier
+    - Construct URL: `https://bedrock-mantle.{region}.api.aws` + `modality.getChatCompletionsPath()`
+    - Resolve authentication via `resolveMantleAuthentication`
+    - Send request via `BedrockMantleClient.sendRequest`
+    - Decode `ChatCompletionsRawOutput` and convert to `ChatCompletionsOutput`
+    - Follow the same structure as `BedrockService+Responses.swift` and `BedrockService+Messages.swift`
+    - _Requirements: 9.5, 9.6, 10.1, 10.4, 10.5, 11.1, 11.3, 11.4, 18.1, 18.2, 18.3_
+
+- [x] 5. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 6. Add mock support and model tests
+  - [x] 6.1 Add OpenAI/Gemma 3 InvokeModel support to `MockBedrockRuntimeClient` in `Tests/Mock/MockBedrockRuntimeClient.swift`
+    - Add a case in `invokeModel` for Gemma 3's modality name (`"Gemma 3 Text Generation"`) that returns an `OpenAIResponseBody`-compatible JSON response
+    - _Requirements: 16.4, 16.5, 20.1, 20.2_
+
+  - [x] 6.2 Create `Tests/Mock/MockBedrockMantleChatCompletionsClient.swift` for Chat Completions mock
+    - Implement `BedrockMantleClientProtocol` that parses the `messages` array from the request body
+    - Return a well-formed Chat Completions JSON response with predictable content ("Mock completion for: {input}")
+    - Support both Gemma 4 and Gemma 3 model IDs
+    - Follow the pattern of `MockBedrockMantleClient.swift`
+    - _Requirements: 10.1, 11.1, 12.1, 12.2_
+
+  - [x] 6.3 Create `Tests/ChatCompletions/ChatCompletionsModelTests.swift` with model definition and modality tests
+    - Test all 6 model IDs and names are correct
+    - Test `hasChatCompletionsModality()` returns true for all 6 models
+    - Test `hasResponsesModality()` returns true for Gemma 4, false for Gemma 3
+    - Test `hasTextModality()` returns false for Gemma 4, true for Gemma 3
+    - Test `hasConverseModality()` returns false for Gemma 4, true for Gemma 3
+    - Test `hasMessagesModality()` returns false for all 6 models
+    - Test `hasImageModality()` returns false for all 6 models
+    - Test `getChatCompletionsPath()` returns correct path per generation
+    - Test `getResponsesPath()` returns `/openai/v1/responses` for Gemma 4
+    - Test `BedrockModel(rawValue:)` resolves all 6 models
+    - Test `BedrockModel(rawValue:)` returns nil for unknown IDs
+    - Test `getTextModality()` throws for Gemma 4
+    - Test `getConverseModality()` throws for Gemma 4
+    - Test `getResponsesModality()` throws for Gemma 3
+    - Test `getMessagesModality()` throws for all 6 models
+    - Test Converse features (textGeneration, vision, systemPrompts) for Gemma 3
+    - _Requirements: 1.1–6.5, 13.1–13.4, 14.1–14.15, 15.1–15.11, 16.1–16.3, 17.1–17.6_
+
+- [x] 7. Add request serialization and response parsing tests
+  - [x] 7.1 Create `Tests/ChatCompletions/ChatCompletionsRequestTests.swift`
+    - Test `ChatCompletionsRequestBody` encodes `model`, `max_completion_tokens`, `messages`, `service_tier` fields correctly
+    - Test default service tier is `"default"` when not specified
+    - Test optional `temperature` and `top_p` fields are omitted when nil
+    - Test `ChatCompletionsMessage` serialization with `role` and `content`
+    - _Requirements: 10.2, 10.3, 11.2_
+
+  - [x] 7.2 Create `Tests/ChatCompletions/ChatCompletionsResponseTests.swift`
+    - Test successful decoding of a valid Chat Completions JSON response
+    - Test `text` field is extracted from first `choices[0].message.content`
+    - Test empty `choices` array throws `completionNotFound`
+    - Test invalid JSON throws a decoding error
+    - Test `OpenAIResponseBody` decoding for Gemma 3 InvokeModel responses (reused wire format)
+    - _Requirements: 12.1, 12.2, 12.3, 12.4, 20.2, 20.3_
+
+- [x] 8. Add service integration tests
+  - [x] 8.1 Create `Tests/ChatCompletions/ChatCompletionsServiceTests.swift`
+    - Test `completeChatCompletion` with a Gemma 4 model returns correct output
+    - Test `completeChatCompletion` with a Gemma 3 model returns correct output
+    - Test `completeChatCompletion` throws `invalidModality` for a model without ChatCompletionsModality (e.g., `.nova_micro`)
+    - Test `completeChatCompletion` throws `notSupported` when both temperature and topP are provided
+    - Test `createResponse` with Gemma 4 model works (Responses API)
+    - Test `completeText` with Gemma 3 model via InvokeModel works
+    - Test `completeText` with Gemma 3 throws when both temperature and topP provided
+    - Test `completeText` with Gemma 3 throws when topK is provided
+    - _Requirements: 9.4, 9.5, 9.6, 10.1, 10.4, 11.1, 11.3, 13.5, 16.4, 16.5, 20.4, 20.5_
+
+- [x] 9. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 10. Add property-based tests
+  - [x] 10.1 Write property test: Unknown raw values resolve to nil
+    - **Property 1: Unknown raw values resolve to nil**
+    - Generate 100 random UUID strings, verify all return nil from `BedrockModel(rawValue:)`
+    - Tag with `// Feature: gemma4-model-support, Property 1: Unknown raw values resolve to nil`
+    - Add to `Tests/ChatCompletions/ChatCompletionsModelTests.swift`
+    - **Validates: Requirements 1.6**
+
+  - [x] 10.2 Write property test: Out-of-range parameter values are rejected
+    - **Property 2: Out-of-range parameter values are rejected**
+    - Generate 100 random out-of-range values for temperature (< 0 or > 2), maxTokens (< 1 or > 8192), topP (< 0 or > 1)
+    - Verify parameter validation throws for each Gemma model
+    - Tag with `// Feature: gemma4-model-support, Property 2: Out-of-range parameter values are rejected`
+    - Add to `Tests/ChatCompletions/ChatCompletionsModelTests.swift`
+    - **Validates: Requirements 7.8, 8.8, 9.5**
+
+  - [x] 10.3 Write property test: Chat Completions request serialization contains required fields
+    - **Property 3: Chat Completions request serialization contains required fields**
+    - Generate 100 random prompts (1–500 chars) with random valid maxTokens [1, 8192]
+    - Serialize `ChatCompletionsRequestBody` and verify JSON contains keys `model`, `max_completion_tokens`, `messages`, `service_tier`
+    - Tag with `// Feature: gemma4-model-support, Property 3: Request serialization contains required fields`
+    - Add to `Tests/ChatCompletions/ChatCompletionsRequestTests.swift`
+    - **Validates: Requirements 10.2, 11.2**
+
+  - [x] 10.4 Write property test: Unsupported parameter combinations throw errors
+    - **Property 4: Unsupported parameter combinations throw errors**
+    - Generate 100 random (temperature, topP) pairs both non-nil, verify throws `notSupported`
+    - Generate 100 random non-nil topK values, verify throws `notSupported`
+    - Tag with `// Feature: gemma4-model-support, Property 4: Unsupported parameter combinations throw errors`
+    - Add to `Tests/ChatCompletions/ChatCompletionsRequestTests.swift`
+    - **Validates: Requirements 10.4, 10.5, 11.3, 11.4, 20.4, 20.5**
+
+  - [x] 10.5 Write property test: Chat Completions response parsing preserves content text
+    - **Property 5: Chat Completions response parsing preserves content text**
+    - Generate 100 random content strings, embed in valid Chat Completions response JSON template
+    - Decode into `ChatCompletionsOutput` and verify `output.text == original content`
+    - Tag with `// Feature: gemma4-model-support, Property 5: Response parsing preserves content text`
+    - Add to `Tests/ChatCompletions/ChatCompletionsResponseTests.swift`
+    - **Validates: Requirements 12.1, 12.2**
+
+  - [x] 10.6 Write property test: InvokeModel response parsing preserves content text (Gemma 3)
+    - **Property 6: InvokeModel response parsing preserves content text (Gemma 3)**
+    - Generate 100 random content strings, embed in OpenAI-format JSON response
+    - Decode via `Gemma3Text.getTextResponseBody()` and verify `completion == original content`
+    - Tag with `// Feature: gemma4-model-support, Property 6: InvokeModel response parsing preserves content`
+    - Add to `Tests/ChatCompletions/ChatCompletionsResponseTests.swift`
+    - **Validates: Requirements 16.5, 20.1, 20.2**
+
+- [x] 11. Create end-to-end Gemma 4 example and add to CI
+  - [x] 11.1 Create `Examples/google-gemma/Package.swift`
+    - Use swift-tools-version 6.0 with macOS 15 / iOS 18 / tvOS 18 platforms
+    - Define executable target `GoogleGemma` depending on `BedrockService` and `swift-log`
+    - Use local path dependency (`../..`) for development, with commented-out production URL
+    - Follow the exact pattern of `Examples/anthropic-messages/Package.swift`
+
+  - [x] 11.2 Create `Examples/google-gemma/Sources/GoogleGemma.swift`
+    - Create a `@main struct Main` with a `static func main() async throws`
+    - Demonstrate the Chat Completions API via bedrock-mantle using `completeChatCompletion` with `.gemma4_31b`
+    - Demonstrate the Responses API via bedrock-mantle using `createResponse` with `.gemma4_31b`
+    - Support both API key (`AWS_BEARER_TOKEN_BEDROCK` env var) and SigV4 authentication (prompt user to choose, like `anthropic-messages` example)
+    - Use region `.useast1`
+    - Print the prompt, response text, and usage information
+    - Include doc comments explaining Gemma 4 is mantle-only (no InvokeModel/Converse)
+    - Follow the code style and structure of `Examples/anthropic-messages/Sources/Messages.swift`
+
+  - [x] 11.3 Add `'google-gemma'` to the examples list in `.github/workflows/pull_request.yml`
+    - Add `'google-gemma'` to the JSON array in the `examples:` parameter of the integration tests job
+    - This ensures the example compiles in CI (CI runs `swift build` on each example)
+
+- [x] 12. Final checkpoint — Ensure all tests pass and example compiles
+  - Ensure all tests pass and `swift build` succeeds in `Examples/google-gemma/`, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The project uses Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) — not XCTest
+- Existing mocks (`MockBedrockMantleClient`, `MockBedrockRuntimeClient`) provide patterns for the new mock
+- Gemma 3 InvokeModel wire format reuses `OpenAIRequestBody`/`OpenAIResponseBody` from the existing OpenAI model support
+- Run tests with `swift test` (never in parallel with other SPM commands)
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["1.2", "2.1"] },
+    { "id": 2, "tasks": ["2.2", "3.1", "3.2"] },
+    { "id": 3, "tasks": ["2.3", "4.1"] },
+    { "id": 4, "tasks": ["6.1", "6.2"] },
+    { "id": 5, "tasks": ["6.3", "7.1", "7.2"] },
+    { "id": 6, "tasks": ["8.1"] },
+    { "id": 7, "tasks": ["10.1", "10.2", "10.3", "10.4", "10.5", "10.6"] },
+    { "id": 8, "tasks": ["11.1", "11.2", "11.3"] }
+  ]
+}
+```

--- a/Examples/google-gemma/Package.swift
+++ b/Examples/google-gemma/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "GoogleGemma",
+    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18)],
+    products: [
+        .executable(name: "GoogleGemma", targets: ["GoogleGemma"])
+    ],
+    dependencies: [
+        // for production use, uncomment the following line
+        // .package(url: "https://github.com/build-on-aws/swift-bedrock-library.git", branch: "main"),
+
+        // for local development, use the following line
+        .package(name: "swift-bedrock-library", path: "../.."),
+
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "GoogleGemma",
+            dependencies: [
+                .product(name: "BedrockService", package: "swift-bedrock-library"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        )
+    ]
+)

--- a/Examples/google-gemma/Sources/GoogleGemma.swift
+++ b/Examples/google-gemma/Sources/GoogleGemma.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BedrockService
+import Foundation
+import Logging
+
+/// Demonstrates Google Gemma 4 text generation via the bedrock-mantle endpoint.
+///
+/// Gemma 4 models are **mantle-only** — they do NOT support InvokeModel or Converse
+/// on bedrock-runtime. All requests route through bedrock-mantle using either:
+/// - The Chat Completions API (`completeChatCompletion`)
+/// - The Responses API (`createResponse`)
+///
+/// This example shows both API paths with `.gemma4_31b`.
+@main
+struct Main {
+    static func main() async throws {
+        do {
+            try await Main.gemma()
+        } catch {
+            print("Error:\n\(error)")
+        }
+    }
+
+    static func gemma() async throws {
+        var logger = Logger(label: "GoogleGemma")
+        logger.logLevel = .debug
+
+        print("Google Gemma 4 via bedrock-mantle")
+        print("==================================")
+        print()
+        print("Choose authentication method:")
+        print("  1. API Key (set AWS_BEARER_TOKEN_BEDROCK environment variable)")
+        print("  2. SigV4 (uses default AWS credential provider chain)")
+        print()
+        print("Enter 1 or 2: ", terminator: "")
+
+        let choice = readLine()?.trimmingCharacters(in: .whitespaces) ?? "1"
+
+        let authentication: BedrockAuthentication
+        switch choice {
+        case "2":
+            print("Using SigV4 with default credential provider chain")
+            authentication = .default
+        default:
+            guard let apiKey = ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] else {
+                print("Error: Set AWS_BEARER_TOKEN_BEDROCK environment variable")
+                print("Create an API key at: https://console.aws.amazon.com/bedrock/home#/api-keys")
+                return
+            }
+            print("Using API Key authentication")
+            authentication = .apiKey(key: apiKey)
+        }
+
+        let bedrock = try await BedrockService(
+            region: .useast1,
+            logger: logger
+        )
+
+        // --- Chat Completions API ---
+        let chatPrompt = "Explain the difference between a compiler and an interpreter in two sentences."
+
+        print()
+        print("--- Chat Completions API ---")
+        print("Prompt: \(chatPrompt)")
+        print()
+
+        let chatResponse = try await bedrock.completeChatCompletion(
+            chatPrompt,
+            with: .gemma4_31b,
+            authentication: authentication
+        )
+
+        print("Response: \(chatResponse.text)")
+        print(
+            "Usage: \(chatResponse.usage.promptTokens) prompt + \(chatResponse.usage.completionTokens) completion = \(chatResponse.usage.totalTokens) total tokens"
+        )
+
+        // --- Responses API ---
+        let responsesPrompt = "What are three benefits of open-source software?"
+
+        print()
+        print("--- Responses API ---")
+        print("Prompt: \(responsesPrompt)")
+        print()
+
+        let responsesResponse = try await bedrock.createResponse(
+            responsesPrompt,
+            with: .gemma4_31b,
+            authentication: authentication
+        )
+
+        print("Response: \(responsesResponse.text)")
+        print("Usage: \(responsesResponse.usage.inputTokens) in / \(responsesResponse.usage.outputTokens) out")
+    }
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/BedrockService+ChatCompletions.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/BedrockService+ChatCompletions.swift
@@ -1,0 +1,186 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AWSSDKIdentity
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension BedrockService {
+
+    /// Generates a chat completion using the Chat Completions API on the bedrock-mantle endpoint.
+    ///
+    /// This convenience overload wraps a single user message. For multi-turn conversations,
+    /// use the overload that accepts `[ChatCompletionsMessage]`.
+    /// - Parameters:
+    ///   - input: The user message text
+    ///   - model: A BedrockModel that supports ChatCompletionsModality
+    ///   - maxTokens: Maximum number of tokens to generate (optional, uses model default if nil)
+    ///   - temperature: Optional temperature for sampling (mutually exclusive with topP)
+    ///   - topP: Optional top-p for nucleus sampling (mutually exclusive with temperature)
+    ///   - serviceTier: The service tier to use (default: .default)
+    ///   - authentication: Authentication method — uses the same BedrockAuthentication as the rest of the library.
+    ///     For `.apiKey`, the key is sent as a Bearer token. For all other methods (`.default`, `.profile`, `.sso`, etc.),
+    ///     credentials are resolved and used for SigV4 signing.
+    ///   - mantleClient: Optional custom client for testing
+    /// - Returns: A ChatCompletionsOutput containing the model's text reply and usage info
+    public func completeChatCompletion(
+        _ input: String,
+        with model: BedrockModel,
+        maxTokens: Int? = nil,
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        serviceTier: ServiceTier = .default,
+        authentication: BedrockAuthentication,
+        mantleClient: BedrockMantleClientProtocol? = nil
+    ) async throws -> ChatCompletionsOutput {
+        try await completeChatCompletion(
+            [ChatCompletionsMessage(role: .user, content: input)],
+            with: model,
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            serviceTier: serviceTier,
+            authentication: authentication,
+            mantleClient: mantleClient
+        )
+    }
+
+    /// Generates a chat completion using the Chat Completions API on the bedrock-mantle endpoint.
+    ///
+    /// Use this overload for multi-turn conversations by passing the full message history.
+    ///
+    /// ```swift
+    /// var messages: [ChatCompletionsMessage] = []
+    /// messages.append("What is Swift?")
+    ///
+    /// let reply = try await bedrock.completeChatCompletion(
+    ///     messages,
+    ///     with: .gemma4_31b,
+    ///     authentication: .default
+    /// )
+    ///
+    /// messages.append(reply)
+    /// messages.append("How does it compare to Kotlin?")
+    ///
+    /// let followUp = try await bedrock.completeChatCompletion(
+    ///     messages,
+    ///     with: .gemma4_31b,
+    ///     authentication: .default
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - messages: The conversation messages (alternating user/assistant roles)
+    ///   - model: A BedrockModel that supports ChatCompletionsModality
+    ///   - maxTokens: Maximum number of tokens to generate (optional, uses model default if nil)
+    ///   - temperature: Optional temperature for sampling (mutually exclusive with topP)
+    ///   - topP: Optional top-p for nucleus sampling (mutually exclusive with temperature)
+    ///   - serviceTier: The service tier to use (default: .default)
+    ///   - authentication: Authentication method — uses the same BedrockAuthentication as the rest of the library.
+    ///     For `.apiKey`, the key is sent as a Bearer token. For all other methods (`.default`, `.profile`, `.sso`, etc.),
+    ///     credentials are resolved and used for SigV4 signing.
+    ///   - mantleClient: Optional custom client for testing
+    /// - Returns: A ChatCompletionsOutput containing the model's text reply and usage info
+    public func completeChatCompletion(
+        _ messages: [ChatCompletionsMessage],
+        with model: BedrockModel,
+        maxTokens: Int? = nil,
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        serviceTier: ServiceTier = .default,
+        authentication: BedrockAuthentication,
+        mantleClient: BedrockMantleClientProtocol? = nil
+    ) async throws -> ChatCompletionsOutput {
+        let modality = try model.getChatCompletionsModality()
+        let parameters = modality.getTextGenerationParameters()
+
+        // Validate: both topP and temperature non-nil → throw notSupported
+        if topP != nil && temperature != nil {
+            throw BedrockLibraryError.notSupported(
+                "Alter either topP or temperature, but not both."
+            )
+        }
+
+        // Validate parameter ranges
+        try parameters.validate(
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP
+        )
+
+        // Resolve maxTokens using model default if not provided
+        guard let resolvedMaxTokens = maxTokens ?? parameters.maxTokens.defaultValue else {
+            throw BedrockLibraryError.notFound(
+                "No value was given for maxTokens and no default value was found"
+            )
+        }
+
+        let requestBody = ChatCompletionsRequestBody(
+            model: model.id,
+            max_completion_tokens: resolvedMaxTokens,
+            messages: messages,
+            service_tier: serviceTier.rawValue,
+            temperature: temperature,
+            top_p: topP
+        )
+
+        let encoder = JSONEncoder()
+        let bodyData = try encoder.encode(requestBody)
+
+        let path = modality.getChatCompletionsPath()
+        let urlString = "https://bedrock-mantle.\(region.rawValue).api.aws\(path)"
+        guard let url = URL(string: urlString, encodingInvalidCharacters: false) else {
+            throw BedrockLibraryError.invalidURI(urlString)
+        }
+
+        logger.trace(
+            "Creating chat completion via bedrock-mantle",
+            metadata: [
+                "model.id": .string(model.id),
+                "url": .string(urlString),
+            ]
+        )
+
+        let mantleAuth = try await resolveMantleAuthentication(authentication)
+
+        let client = mantleClient ?? BedrockMantleClient(region: region.rawValue, logger: self.logger)
+        let responseData = try await client.sendRequest(
+            body: bodyData,
+            url: url,
+            authentication: mantleAuth
+        )
+
+        let decoder = JSONDecoder()
+        let rawOutput = try decoder.decode(ChatCompletionsRawOutput.self, from: responseData)
+
+        let output = try ChatCompletionsOutput(from: rawOutput)
+
+        logger.trace(
+            "Received chat completion from bedrock-mantle",
+            metadata: [
+                "model.id": .string(model.id),
+                "response.id": .string(output.id),
+                "usage.promptTokens": .stringConvertible(output.usage.promptTokens),
+                "usage.completionTokens": .stringConvertible(output.usage.completionTokens),
+            ]
+        )
+
+        return output
+    }
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/ChatCompletionsInput.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/ChatCompletionsInput.swift
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+struct ChatCompletionsRequestBody: Codable, Sendable {
+    let model: String
+    let max_completion_tokens: Int
+    let messages: [ChatCompletionsMessage]
+    let service_tier: String
+    let temperature: Double?
+    let top_p: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case max_completion_tokens
+        case messages
+        case service_tier
+        case temperature
+        case top_p
+    }
+}
+
+/// A message in a Chat Completions conversation.
+///
+/// Each message has a ``role`` (system, user, or assistant) and text ``content``.
+/// Build a conversation by appending messages to an array:
+///
+/// ```swift
+/// var messages: [ChatCompletionsMessage] = []
+/// messages.append("What is Swift?")
+///
+/// let reply = try await bedrock.completeChatCompletion(
+///     messages,
+///     with: .gemma4_31b,
+///     authentication: authentication
+/// )
+///
+/// messages.append(reply)
+/// messages.append("How does it compare to Kotlin?")
+/// ```
+public struct ChatCompletionsMessage: Codable, Sendable {
+    /// The role of the message author.
+    public let role: ChatCompletionsRole
+    /// The text content of the message.
+    public let content: String
+
+    /// Creates a new message with the given role and content.
+    public init(role: ChatCompletionsRole, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+/// The role of a message in a Chat Completions conversation.
+public enum ChatCompletionsRole: String, Codable, Sendable {
+    /// A system prompt that sets the behavior of the assistant.
+    case system
+    /// A message from the user.
+    case user
+    /// A reply from the model.
+    case assistant
+}
+
+extension [ChatCompletionsMessage] {
+    /// Appends the model's reply as an assistant message.
+    public mutating func append(_ output: ChatCompletionsOutput) {
+        append(ChatCompletionsMessage(role: .assistant, content: output.text))
+    }
+
+    /// Appends a user message from a plain string.
+    public mutating func append(_ userMessage: String) {
+        append(ChatCompletionsMessage(role: .user, content: userMessage))
+    }
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/ChatCompletionsOutput.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/ChatCompletionsOutput.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// The response from a Chat Completions API call.
+///
+/// Contains the generated text, model identifier, and token usage statistics.
+public struct ChatCompletionsOutput: Sendable {
+    /// The unique identifier for this completion.
+    public let id: String
+    /// The generated text extracted from the first choice.
+    public let text: String
+    /// The model identifier that generated this completion.
+    public let model: String
+    /// Token usage statistics for this completion.
+    public let usage: ChatCompletionsUsage
+
+    init(from raw: ChatCompletionsRawOutput) throws {
+        self.id = raw.id
+        self.model = raw.model
+        guard let firstChoice = raw.choices.first else {
+            throw BedrockLibraryError.completionNotFound(
+                "No choices available in Chat Completions response"
+            )
+        }
+        self.text = firstChoice.message.content
+        self.usage = ChatCompletionsUsage(
+            promptTokens: raw.usage.prompt_tokens,
+            completionTokens: raw.usage.completion_tokens,
+            totalTokens: raw.usage.total_tokens
+        )
+    }
+}
+
+/// Token usage statistics from a Chat Completions response.
+public struct ChatCompletionsUsage: Sendable {
+    /// The number of tokens in the prompt.
+    public let promptTokens: Int
+    /// The number of tokens in the generated completion.
+    public let completionTokens: Int
+    /// The total number of tokens used (prompt + completion).
+    public let totalTokens: Int
+}
+
+struct ChatCompletionsRawOutput: Codable, Sendable {
+    let id: String
+    let choices: [ChatCompletionsChoice]
+    let created: Int
+    let model: String
+    let object: String
+    let usage: ChatCompletionsRawUsage
+}
+
+struct ChatCompletionsChoice: Codable, Sendable {
+    let finish_reason: String
+    let index: Int
+    let message: ChatCompletionsResponseMessage
+}
+
+struct ChatCompletionsResponseMessage: Codable, Sendable {
+    let content: String
+    let role: String
+}
+
+struct ChatCompletionsRawUsage: Codable, Sendable {
+    let completion_tokens: Int
+    let prompt_tokens: Int
+    let total_tokens: Int
+}

--- a/Sources/BedrockService/BedrockRuntimeClient/Modalities/ChatCompletionsModality.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Modalities/ChatCompletionsModality.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public protocol ChatCompletionsModality: Modality {
+    func getChatCompletionsPath() -> String
+    func getTextGenerationParameters() -> TextGenerationParameters
+}

--- a/Sources/BedrockService/Docs.docc/BedrockService.md
+++ b/Sources/BedrockService/Docs.docc/BedrockService.md
@@ -22,6 +22,7 @@ BedrockService is a lightweight layer on top of the AWS SDK for Swift that provi
 
 ### Core Features
 
+- <doc:ChatCompletions>
 - <doc:Converse>
 - <doc:Messages>
 - <doc:Responses>

--- a/Sources/BedrockService/Docs.docc/ChatCompletions.md
+++ b/Sources/BedrockService/Docs.docc/ChatCompletions.md
@@ -1,0 +1,186 @@
+# Chat Completions API
+
+Use Google Gemma models on Amazon Bedrock via the OpenAI-compatible Chat Completions API
+
+## Overview
+
+The Chat Completions API provides access to Google Gemma models hosted on Amazon Bedrock through the `bedrock-mantle` endpoint. This API uses the OpenAI-compatible chat completions protocol and supports multi-turn conversations.
+
+Like the Responses and Messages APIs, the Chat Completions API requires explicit authentication — you pass a ``BedrockAuthentication`` value directly to the call.
+
+## Supported Models
+
+| Model | Identifier | Endpoint |
+|-------|-----------|----------|
+| Gemma 4 31B | `.gemma4_31b` | `/openai/v1/chat/completions` |
+| Gemma 4 26B-A4B | `.gemma4_26b_a4b` | `/openai/v1/chat/completions` |
+| Gemma 4 E2B | `.gemma4_e2b` | `/openai/v1/chat/completions` |
+| Gemma 3 27B IT | `.gemma3_27b_it` | `/v1/chat/completions` |
+| Gemma 3 12B IT | `.gemma3_12b_it` | `/v1/chat/completions` |
+| Gemma 3 4B IT | `.gemma3_4b_it` | `/v1/chat/completions` |
+
+> Note: Gemma 4 models are **mantle-only** — they support Chat Completions and Responses APIs but not InvokeModel or Converse. Gemma 3 models support Chat Completions, InvokeModel (``BedrockService/completeText(_:with:maxTokens:temperature:topP:topK:stopSequences:serviceTier:)``), and the Converse API.
+
+## Basic Usage
+
+Send a single prompt and receive a text response:
+
+```swift
+let bedrock = try await BedrockService(region: .useast1)
+
+let reply = try await bedrock.completeChatCompletion(
+    "Explain quantum computing in simple terms",
+    with: .gemma4_31b,
+    authentication: .default
+)
+
+print("Response: \(reply.text)")
+print("Tokens: \(reply.usage.promptTokens) in / \(reply.usage.completionTokens) out")
+```
+
+## Multi-Turn Conversations
+
+The Chat Completions API is stateless — you send the full conversation history with each request. The library provides convenience `append` overloads on `[ChatCompletionsMessage]` so you can append a `String` (as a user message) or a ``ChatCompletionsOutput`` (as an assistant message) directly:
+
+```swift
+let bedrock = try await BedrockService(region: .useast1)
+
+// Start a conversation
+var messages: [ChatCompletionsMessage] = []
+messages.append("What is quantum computing?")
+
+let reply1 = try await bedrock.completeChatCompletion(
+    messages,
+    with: .gemma4_31b,
+    authentication: .default
+)
+
+// Append the assistant's reply and ask a follow-up
+messages.append(reply1)
+messages.append("Can you give a real-world example?")
+
+let reply2 = try await bedrock.completeChatCompletion(
+    messages,
+    with: .gemma4_31b,
+    authentication: .default
+)
+
+print(reply2.text)
+```
+
+## System Prompts
+
+Use the `.system` role to set the assistant's behavior:
+
+```swift
+var messages: [ChatCompletionsMessage] = [
+    ChatCompletionsMessage(role: .system, content: "You are a concise technical writer.")
+]
+messages.append("What is Swift concurrency?")
+
+let reply = try await bedrock.completeChatCompletion(
+    messages,
+    with: .gemma4_31b,
+    authentication: .default
+)
+```
+
+## Authentication
+
+The Chat Completions API supports the same authentication methods as the rest of the library (see <doc:Authentication>).
+
+### API Key (Bearer Token)
+
+```swift
+let reply = try await bedrock.completeChatCompletion(
+    "Hello!",
+    with: .gemma4_31b,
+    authentication: .apiKey(key: "your-api-key")
+)
+```
+
+> Important: Never hardcode API keys in your application. Use environment variables or secure storage.
+
+### SigV4 (AWS Credentials)
+
+```swift
+// Default credential chain
+let reply = try await bedrock.completeChatCompletion(
+    "Hello!",
+    with: .gemma4_31b,
+    authentication: .default
+)
+
+// Named profile
+let reply = try await bedrock.completeChatCompletion(
+    "Hello!",
+    with: .gemma4_31b,
+    authentication: .profile(profileName: "my-profile")
+)
+```
+
+## Controlling Generation Parameters
+
+Specify temperature, top-p, and max tokens:
+
+```swift
+let reply = try await bedrock.completeChatCompletion(
+    "Write a haiku about Swift",
+    with: .gemma4_31b,
+    maxTokens: 256,
+    temperature: 0.7,
+    authentication: .default
+)
+```
+
+> Important: Temperature and top-p are mutually exclusive. Providing both throws a `notSupported` error. Top-k is not supported for Gemma models.
+
+| Parameter | Range | Default |
+|-----------|-------|---------|
+| temperature | 0 – 2 | 1 |
+| maxTokens | 1 – 8192 | 8192 |
+| topP | 0 – 1 | 1 |
+| topK | — | Not supported |
+
+## Response Structure
+
+The ``ChatCompletionsOutput`` contains:
+
+- `id` — Unique completion identifier
+- `text` — The model's generated text (from the first choice)
+- `model` — The model identifier string returned by the API
+- `usage` — Token usage with `promptTokens`, `completionTokens`, and `totalTokens`
+
+## Gemma 3 via InvokeModel
+
+Gemma 3 models also support the traditional `completeText` path via bedrock-runtime:
+
+```swift
+let completion: TextCompletion = try await bedrock.completeText(
+    "Explain recursion",
+    with: .gemma3_27b_it
+)
+
+print(completion.completion)
+```
+
+## Gemma 4 via Responses API
+
+Gemma 4 models also support the Responses API for extended features:
+
+```swift
+let response = try await bedrock.createResponse(
+    "What are three benefits of open-source software?",
+    with: .gemma4_31b,
+    authentication: .default
+)
+
+print(response.text)
+```
+
+## See Also
+
+- <doc:Authentication>
+- <doc:Responses>
+- <doc:Messages>
+- <doc:TextGeneration>

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -137,6 +137,13 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
         case BedrockModel.openai_gpt_oss_120b.id: self = BedrockModel.openai_gpt_oss_120b
         case BedrockModel.openai_gpt_5_5.id: self = BedrockModel.openai_gpt_5_5
         case BedrockModel.openai_gpt_5_4.id: self = BedrockModel.openai_gpt_5_4
+        // google
+        case BedrockModel.gemma4_31b.id: self = BedrockModel.gemma4_31b
+        case BedrockModel.gemma4_26b_a4b.id: self = BedrockModel.gemma4_26b_a4b
+        case BedrockModel.gemma4_e2b.id: self = BedrockModel.gemma4_e2b
+        case BedrockModel.gemma3_27b_it.id: self = BedrockModel.gemma3_27b_it
+        case BedrockModel.gemma3_12b_it.id: self = BedrockModel.gemma3_12b_it
+        case BedrockModel.gemma3_4b_it.id: self = BedrockModel.gemma3_4b_it
         // stability
         case BedrockModel.stable_image_core.id: self = BedrockModel.stable_image_core
         case BedrockModel.stable_image_ultra.id: self = BedrockModel.stable_image_ultra
@@ -314,6 +321,27 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
             )
         }
         return responsesModality
+    }
+
+    // MARK - Chat Completions
+
+    /// Checks if the model supports the Chat Completions API (bedrock-mantle)
+    /// - Returns: True if the model supports the Chat Completions API
+    public func hasChatCompletionsModality() -> Bool {
+        modality as? any ChatCompletionsModality != nil
+    }
+
+    /// Checks if the model supports the Chat Completions API and returns ChatCompletionsModality
+    /// - Returns: ChatCompletionsModality if the model supports the Chat Completions API
+    public func getChatCompletionsModality() throws -> any ChatCompletionsModality {
+        guard let chatCompletionsModality = modality as? any ChatCompletionsModality else {
+            throw BedrockLibraryError.invalidModality(
+                self,
+                modality,
+                "Model \(id) does not support the Chat Completions API"
+            )
+        }
+        return chatCompletionsModality
     }
 
     // MARK - Converse

--- a/Sources/BedrockService/Models/Google/Google.swift
+++ b/Sources/BedrockService/Models/Google/Google.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+struct Gemma4Text: ChatCompletionsModality, ResponsesModality {
+    let parameters: TextGenerationParameters
+
+    func getName() -> String { "Gemma 4 Text Generation" }
+    func getChatCompletionsPath() -> String { "/openai/v1/chat/completions" }
+    func getResponsesPath() -> String { "/openai/v1/responses" }
+    func getTextGenerationParameters() -> TextGenerationParameters { parameters }
+}
+
+struct Gemma3Text: TextModality, ConverseModality, ChatCompletionsModality {
+    let parameters: TextGenerationParameters
+    let converseParameters: ConverseParameters
+    let converseFeatures: [ConverseFeature]
+
+    func getName() -> String { "Gemma 3 Text Generation" }
+    func getChatCompletionsPath() -> String { "/v1/chat/completions" }
+    func getTextGenerationParameters() -> TextGenerationParameters { parameters }
+
+    init(
+        parameters: TextGenerationParameters,
+        features: [ConverseFeature] = [.textGeneration, .vision, .systemPrompts]
+    ) {
+        self.parameters = parameters
+        self.converseFeatures = features
+        self.converseParameters = ConverseParameters(textGenerationParameters: parameters)
+    }
+
+    func getParameters() -> TextGenerationParameters {
+        parameters
+    }
+
+    func getTextRequestBody(
+        prompt: String,
+        maxTokens: Int?,
+        temperature: Double?,
+        topP: Double?,
+        topK: Int?,
+        stopSequences: [String]?,
+        serviceTier: ServiceTier
+    ) throws -> BedrockBodyCodable {
+        guard let maxTokens = maxTokens ?? parameters.maxTokens.defaultValue else {
+            throw BedrockLibraryError.notFound(
+                "No value was given for maxTokens and no default value was found"
+            )
+        }
+        if topP != nil && temperature != nil {
+            throw BedrockLibraryError.notSupported(
+                "Alter either topP or temperature, but not both."
+            )
+        }
+        guard topK == nil else {
+            throw BedrockLibraryError.notSupported(
+                "TopK is not supported for Gemma 3 text completion"
+            )
+        }
+        return OpenAIRequestBody(
+            prompt: prompt,
+            maxTokens: maxTokens,
+            temperature: temperature ?? parameters.temperature.defaultValue,
+            topP: topP ?? parameters.topP.defaultValue,
+            serviceTier: serviceTier
+        )
+    }
+
+    func getTextResponseBody(from data: Data) throws -> ContainsTextCompletion {
+        let decoder = JSONDecoder()
+        return try decoder.decode(OpenAIResponseBody.self, from: data)
+    }
+}

--- a/Sources/BedrockService/Models/Google/GoogleBedrockModels.swift
+++ b/Sources/BedrockService/Models/Google/GoogleBedrockModels.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-google.html
+
+extension BedrockModel {
+    public static let gemma4_31b: BedrockModel = BedrockModel(
+        id: "google.gemma-4-31b",
+        name: "Gemma 4 31B",
+        modality: Gemma4Text(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 2, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+    public static let gemma4_26b_a4b: BedrockModel = BedrockModel(
+        id: "google.gemma-4-26b-a4b",
+        name: "Gemma 4 26B-A4B",
+        modality: Gemma4Text(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 2, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+    public static let gemma4_e2b: BedrockModel = BedrockModel(
+        id: "google.gemma-4-e2b",
+        name: "Gemma 4 E2B",
+        modality: Gemma4Text(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 2, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+    public static let gemma3_27b_it: BedrockModel = BedrockModel(
+        id: "google.gemma-3-27b-it",
+        name: "Gemma 3 27B IT",
+        modality: Gemma3Text(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 2, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+    public static let gemma3_12b_it: BedrockModel = BedrockModel(
+        id: "google.gemma-3-12b-it",
+        name: "Gemma 3 12B IT",
+        modality: Gemma3Text(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 2, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+    public static let gemma3_4b_it: BedrockModel = BedrockModel(
+        id: "google.gemma-3-4b-it",
+        name: "Gemma 3 4B IT",
+        modality: Gemma3Text(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 2, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+}

--- a/Tests/ChatCompletions/ChatCompletionsModelTests.swift
+++ b/Tests/ChatCompletions/ChatCompletionsModelTests.swift
@@ -1,0 +1,481 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AwsCommonRuntimeKit
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+@Suite("ChatCompletions Model Tests")
+struct ChatCompletionsModelTests {
+
+    // MARK: - Model IDs and Names
+
+    @Test("Gemma 4 31B has correct model ID")
+    func gemma4_31bModelId() {
+        #expect(BedrockModel.gemma4_31b.id == "google.gemma-4-31b")
+    }
+
+    @Test("Gemma 4 31B has correct name")
+    func gemma4_31bModelName() {
+        #expect(BedrockModel.gemma4_31b.name == "Gemma 4 31B")
+    }
+
+    @Test("Gemma 4 26B-A4B has correct model ID")
+    func gemma4_26b_a4bModelId() {
+        #expect(BedrockModel.gemma4_26b_a4b.id == "google.gemma-4-26b-a4b")
+    }
+
+    @Test("Gemma 4 26B-A4B has correct name")
+    func gemma4_26b_a4bModelName() {
+        #expect(BedrockModel.gemma4_26b_a4b.name == "Gemma 4 26B-A4B")
+    }
+
+    @Test("Gemma 4 E2B has correct model ID")
+    func gemma4_e2bModelId() {
+        #expect(BedrockModel.gemma4_e2b.id == "google.gemma-4-e2b")
+    }
+
+    @Test("Gemma 4 E2B has correct name")
+    func gemma4_e2bModelName() {
+        #expect(BedrockModel.gemma4_e2b.name == "Gemma 4 E2B")
+    }
+
+    @Test("Gemma 3 27B IT has correct model ID")
+    func gemma3_27b_itModelId() {
+        #expect(BedrockModel.gemma3_27b_it.id == "google.gemma-3-27b-it")
+    }
+
+    @Test("Gemma 3 27B IT has correct name")
+    func gemma3_27b_itModelName() {
+        #expect(BedrockModel.gemma3_27b_it.name == "Gemma 3 27B IT")
+    }
+
+    @Test("Gemma 3 12B IT has correct model ID")
+    func gemma3_12b_itModelId() {
+        #expect(BedrockModel.gemma3_12b_it.id == "google.gemma-3-12b-it")
+    }
+
+    @Test("Gemma 3 12B IT has correct name")
+    func gemma3_12b_itModelName() {
+        #expect(BedrockModel.gemma3_12b_it.name == "Gemma 3 12B IT")
+    }
+
+    @Test("Gemma 3 4B IT has correct model ID")
+    func gemma3_4b_itModelId() {
+        #expect(BedrockModel.gemma3_4b_it.id == "google.gemma-3-4b-it")
+    }
+
+    @Test("Gemma 3 4B IT has correct name")
+    func gemma3_4b_itModelName() {
+        #expect(BedrockModel.gemma3_4b_it.name == "Gemma 3 4B IT")
+    }
+
+    // MARK: - hasChatCompletionsModality
+
+    @Test("All Gemma 4 models have chat completions modality")
+    func gemma4HasChatCompletionsModality() {
+        #expect(BedrockModel.gemma4_31b.hasChatCompletionsModality())
+        #expect(BedrockModel.gemma4_26b_a4b.hasChatCompletionsModality())
+        #expect(BedrockModel.gemma4_e2b.hasChatCompletionsModality())
+    }
+
+    @Test("All Gemma 3 models have chat completions modality")
+    func gemma3HasChatCompletionsModality() {
+        #expect(BedrockModel.gemma3_27b_it.hasChatCompletionsModality())
+        #expect(BedrockModel.gemma3_12b_it.hasChatCompletionsModality())
+        #expect(BedrockModel.gemma3_4b_it.hasChatCompletionsModality())
+    }
+
+    // MARK: - hasResponsesModality
+
+    @Test("All Gemma 4 models have responses modality")
+    func gemma4HasResponsesModality() {
+        #expect(BedrockModel.gemma4_31b.hasResponsesModality())
+        #expect(BedrockModel.gemma4_26b_a4b.hasResponsesModality())
+        #expect(BedrockModel.gemma4_e2b.hasResponsesModality())
+    }
+
+    @Test("All Gemma 3 models do not have responses modality")
+    func gemma3NoResponsesModality() {
+        #expect(!BedrockModel.gemma3_27b_it.hasResponsesModality())
+        #expect(!BedrockModel.gemma3_12b_it.hasResponsesModality())
+        #expect(!BedrockModel.gemma3_4b_it.hasResponsesModality())
+    }
+
+    // MARK: - hasTextModality
+
+    @Test("All Gemma 4 models do not have text modality")
+    func gemma4NoTextModality() {
+        #expect(!BedrockModel.gemma4_31b.hasTextModality())
+        #expect(!BedrockModel.gemma4_26b_a4b.hasTextModality())
+        #expect(!BedrockModel.gemma4_e2b.hasTextModality())
+    }
+
+    @Test("All Gemma 3 models have text modality")
+    func gemma3HasTextModality() {
+        #expect(BedrockModel.gemma3_27b_it.hasTextModality())
+        #expect(BedrockModel.gemma3_12b_it.hasTextModality())
+        #expect(BedrockModel.gemma3_4b_it.hasTextModality())
+    }
+
+    // MARK: - hasConverseModality
+
+    @Test("All Gemma 4 models do not have converse modality")
+    func gemma4NoConverseModality() {
+        #expect(!BedrockModel.gemma4_31b.hasConverseModality())
+        #expect(!BedrockModel.gemma4_26b_a4b.hasConverseModality())
+        #expect(!BedrockModel.gemma4_e2b.hasConverseModality())
+    }
+
+    @Test("All Gemma 3 models have converse modality")
+    func gemma3HasConverseModality() {
+        #expect(BedrockModel.gemma3_27b_it.hasConverseModality())
+        #expect(BedrockModel.gemma3_12b_it.hasConverseModality())
+        #expect(BedrockModel.gemma3_4b_it.hasConverseModality())
+    }
+
+    // MARK: - hasMessagesModality
+
+    @Test("All Gemma models do not have messages modality")
+    func allGemmaNoMessagesModality() {
+        #expect(!BedrockModel.gemma4_31b.hasMessagesModality())
+        #expect(!BedrockModel.gemma4_26b_a4b.hasMessagesModality())
+        #expect(!BedrockModel.gemma4_e2b.hasMessagesModality())
+        #expect(!BedrockModel.gemma3_27b_it.hasMessagesModality())
+        #expect(!BedrockModel.gemma3_12b_it.hasMessagesModality())
+        #expect(!BedrockModel.gemma3_4b_it.hasMessagesModality())
+    }
+
+    // MARK: - hasImageModality
+
+    @Test("All Gemma models do not have image modality")
+    func allGemmaNoImageModality() {
+        #expect(!BedrockModel.gemma4_31b.hasImageModality())
+        #expect(!BedrockModel.gemma4_26b_a4b.hasImageModality())
+        #expect(!BedrockModel.gemma4_e2b.hasImageModality())
+        #expect(!BedrockModel.gemma3_27b_it.hasImageModality())
+        #expect(!BedrockModel.gemma3_12b_it.hasImageModality())
+        #expect(!BedrockModel.gemma3_4b_it.hasImageModality())
+    }
+
+    // MARK: - getChatCompletionsPath
+
+    @Test("Gemma 4 models use /openai/v1/chat/completions path")
+    func gemma4ChatCompletionsPath() throws {
+        let modality31b = try BedrockModel.gemma4_31b.getChatCompletionsModality()
+        #expect(modality31b.getChatCompletionsPath() == "/openai/v1/chat/completions")
+
+        let modality26b = try BedrockModel.gemma4_26b_a4b.getChatCompletionsModality()
+        #expect(modality26b.getChatCompletionsPath() == "/openai/v1/chat/completions")
+
+        let modalityE2b = try BedrockModel.gemma4_e2b.getChatCompletionsModality()
+        #expect(modalityE2b.getChatCompletionsPath() == "/openai/v1/chat/completions")
+    }
+
+    @Test("Gemma 3 models use /v1/chat/completions path")
+    func gemma3ChatCompletionsPath() throws {
+        let modality27b = try BedrockModel.gemma3_27b_it.getChatCompletionsModality()
+        #expect(modality27b.getChatCompletionsPath() == "/v1/chat/completions")
+
+        let modality12b = try BedrockModel.gemma3_12b_it.getChatCompletionsModality()
+        #expect(modality12b.getChatCompletionsPath() == "/v1/chat/completions")
+
+        let modality4b = try BedrockModel.gemma3_4b_it.getChatCompletionsModality()
+        #expect(modality4b.getChatCompletionsPath() == "/v1/chat/completions")
+    }
+
+    // MARK: - getResponsesPath
+
+    @Test("Gemma 4 models use /openai/v1/responses path")
+    func gemma4ResponsesPath() throws {
+        let modality31b = try BedrockModel.gemma4_31b.getResponsesModality()
+        #expect(modality31b.getResponsesPath() == "/openai/v1/responses")
+
+        let modality26b = try BedrockModel.gemma4_26b_a4b.getResponsesModality()
+        #expect(modality26b.getResponsesPath() == "/openai/v1/responses")
+
+        let modalityE2b = try BedrockModel.gemma4_e2b.getResponsesModality()
+        #expect(modalityE2b.getResponsesPath() == "/openai/v1/responses")
+    }
+
+    // MARK: - BedrockModel(rawValue:) resolves all 6 models
+
+    @Test("Gemma 4 31B is resolvable from rawValue")
+    func gemma4_31bRawValue() {
+        let model = BedrockModel(rawValue: "google.gemma-4-31b")
+        #expect(model != nil)
+        #expect(model?.name == "Gemma 4 31B")
+    }
+
+    @Test("Gemma 4 26B-A4B is resolvable from rawValue")
+    func gemma4_26b_a4bRawValue() {
+        let model = BedrockModel(rawValue: "google.gemma-4-26b-a4b")
+        #expect(model != nil)
+        #expect(model?.name == "Gemma 4 26B-A4B")
+    }
+
+    @Test("Gemma 4 E2B is resolvable from rawValue")
+    func gemma4_e2bRawValue() {
+        let model = BedrockModel(rawValue: "google.gemma-4-e2b")
+        #expect(model != nil)
+        #expect(model?.name == "Gemma 4 E2B")
+    }
+
+    @Test("Gemma 3 27B IT is resolvable from rawValue")
+    func gemma3_27b_itRawValue() {
+        let model = BedrockModel(rawValue: "google.gemma-3-27b-it")
+        #expect(model != nil)
+        #expect(model?.name == "Gemma 3 27B IT")
+    }
+
+    @Test("Gemma 3 12B IT is resolvable from rawValue")
+    func gemma3_12b_itRawValue() {
+        let model = BedrockModel(rawValue: "google.gemma-3-12b-it")
+        #expect(model != nil)
+        #expect(model?.name == "Gemma 3 12B IT")
+    }
+
+    @Test("Gemma 3 4B IT is resolvable from rawValue")
+    func gemma3_4b_itRawValue() {
+        let model = BedrockModel(rawValue: "google.gemma-3-4b-it")
+        #expect(model != nil)
+        #expect(model?.name == "Gemma 3 4B IT")
+    }
+
+    // MARK: - Unknown raw values return nil
+
+    @Test("Unknown model IDs return nil from rawValue initializer")
+    func unknownRawValueReturnsNil() {
+        #expect(BedrockModel(rawValue: "google.gemma-5-100b") == nil)
+        #expect(BedrockModel(rawValue: "unknown.model") == nil)
+        #expect(BedrockModel(rawValue: "") == nil)
+    }
+
+    // MARK: - getTextModality throws for Gemma 4
+
+    @Test("getTextModality throws for Gemma 4 models")
+    func gemma4GetTextModalityThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma4_31b.getTextModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma4_26b_a4b.getTextModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma4_e2b.getTextModality()
+        }
+    }
+
+    // MARK: - getConverseModality throws for Gemma 4
+
+    @Test("getConverseModality throws for Gemma 4 models")
+    func gemma4GetConverseModalityThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma4_31b.getConverseModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma4_26b_a4b.getConverseModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma4_e2b.getConverseModality()
+        }
+    }
+
+    // MARK: - getResponsesModality throws for Gemma 3
+
+    @Test("getResponsesModality throws for Gemma 3 models")
+    func gemma3GetResponsesModalityThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma3_27b_it.getResponsesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma3_12b_it.getResponsesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma3_4b_it.getResponsesModality()
+        }
+    }
+
+    // MARK: - getMessagesModality throws for all 6 models
+
+    @Test("getMessagesModality throws for all Gemma models")
+    func allGemmaGetMessagesModalityThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma4_31b.getMessagesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma4_26b_a4b.getMessagesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma4_e2b.getMessagesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma3_27b_it.getMessagesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma3_12b_it.getMessagesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.gemma3_4b_it.getMessagesModality()
+        }
+    }
+
+    // MARK: - Converse features for Gemma 3
+
+    @Test("Gemma 3 models support textGeneration converse feature")
+    func gemma3HasTextGenerationFeature() {
+        #expect(BedrockModel.gemma3_27b_it.hasConverseModality(.textGeneration))
+        #expect(BedrockModel.gemma3_12b_it.hasConverseModality(.textGeneration))
+        #expect(BedrockModel.gemma3_4b_it.hasConverseModality(.textGeneration))
+    }
+
+    @Test("Gemma 3 models support vision converse feature")
+    func gemma3HasVisionFeature() {
+        #expect(BedrockModel.gemma3_27b_it.hasConverseModality(.vision))
+        #expect(BedrockModel.gemma3_12b_it.hasConverseModality(.vision))
+        #expect(BedrockModel.gemma3_4b_it.hasConverseModality(.vision))
+    }
+
+    @Test("Gemma 3 models support systemPrompts converse feature")
+    func gemma3HasSystemPromptsFeature() {
+        #expect(BedrockModel.gemma3_27b_it.hasConverseModality(.systemPrompts))
+        #expect(BedrockModel.gemma3_12b_it.hasConverseModality(.systemPrompts))
+        #expect(BedrockModel.gemma3_4b_it.hasConverseModality(.systemPrompts))
+    }
+
+    // MARK: - Property-Based Tests
+
+    // Feature: gemma4-model-support, Property 1: Unknown raw values resolve to nil
+    // Validates: Requirements 1.6
+    @Test("Unknown raw values resolve to nil", arguments: (0..<100).map { _ in UUID().uuidString })
+    func unknownRawValuesResolveToNil(randomId: String) {
+        #expect(BedrockModel(rawValue: randomId) == nil)
+    }
+
+    // Feature: gemma4-model-support, Property 2: Out-of-range parameter values are rejected
+    // Validates: Requirements 7.8, 8.8, 9.5
+    @Test("Out-of-range temperature values are rejected for all Gemma models")
+    func outOfRangeTemperatureRejected() async throws {
+        CommonRuntimeKit.initialize()
+        let bedrock = try await BedrockService(
+            region: .useast1,
+            bedrockClient: MockBedrockClient(),
+            bedrockRuntimeClient: MockBedrockRuntimeClient()
+        )
+
+        let gemmaModels: [BedrockModel] = [
+            .gemma4_31b, .gemma4_26b_a4b, .gemma4_e2b,
+            .gemma3_27b_it, .gemma3_12b_it, .gemma3_4b_it,
+        ]
+
+        for _ in 0..<100 {
+            // Generate random out-of-range temperature: either < 0 or > 2
+            let outOfRange: Double
+            if Bool.random() {
+                outOfRange = -Double.random(in: 0.001...1000.0)
+            } else {
+                outOfRange = Double.random(in: 2.001...1000.0)
+            }
+
+            for model in gemmaModels {
+                await #expect(throws: BedrockLibraryError.self) {
+                    _ = try await bedrock.completeChatCompletion(
+                        "test",
+                        with: model,
+                        temperature: outOfRange,
+                        authentication: .apiKey(key: "test-key"),
+                        mantleClient: MockBedrockMantleChatCompletionsClient()
+                    )
+                }
+            }
+        }
+    }
+
+    @Test("Out-of-range maxTokens values are rejected for all Gemma models")
+    func outOfRangeMaxTokensRejected() async throws {
+        CommonRuntimeKit.initialize()
+        let bedrock = try await BedrockService(
+            region: .useast1,
+            bedrockClient: MockBedrockClient(),
+            bedrockRuntimeClient: MockBedrockRuntimeClient()
+        )
+
+        let gemmaModels: [BedrockModel] = [
+            .gemma4_31b, .gemma4_26b_a4b, .gemma4_e2b,
+            .gemma3_27b_it, .gemma3_12b_it, .gemma3_4b_it,
+        ]
+
+        for _ in 0..<100 {
+            // Generate random out-of-range maxTokens: either < 1 or > 8192
+            let outOfRange: Int
+            if Bool.random() {
+                outOfRange = Int.random(in: -1000...0)
+            } else {
+                outOfRange = Int.random(in: 8193...100000)
+            }
+
+            for model in gemmaModels {
+                await #expect(throws: BedrockLibraryError.self) {
+                    _ = try await bedrock.completeChatCompletion(
+                        "test",
+                        with: model,
+                        maxTokens: outOfRange,
+                        authentication: .apiKey(key: "test-key"),
+                        mantleClient: MockBedrockMantleChatCompletionsClient()
+                    )
+                }
+            }
+        }
+    }
+
+    @Test("Out-of-range topP values are rejected for all Gemma models")
+    func outOfRangeTopPRejected() async throws {
+        CommonRuntimeKit.initialize()
+        let bedrock = try await BedrockService(
+            region: .useast1,
+            bedrockClient: MockBedrockClient(),
+            bedrockRuntimeClient: MockBedrockRuntimeClient()
+        )
+
+        let gemmaModels: [BedrockModel] = [
+            .gemma4_31b, .gemma4_26b_a4b, .gemma4_e2b,
+            .gemma3_27b_it, .gemma3_12b_it, .gemma3_4b_it,
+        ]
+
+        for _ in 0..<100 {
+            // Generate random out-of-range topP: either < 0 or > 1
+            let outOfRange: Double
+            if Bool.random() {
+                outOfRange = -Double.random(in: 0.001...1000.0)
+            } else {
+                outOfRange = Double.random(in: 1.001...1000.0)
+            }
+
+            for model in gemmaModels {
+                await #expect(throws: BedrockLibraryError.self) {
+                    _ = try await bedrock.completeChatCompletion(
+                        "test",
+                        with: model,
+                        topP: outOfRange,
+                        authentication: .apiKey(key: "test-key"),
+                        mantleClient: MockBedrockMantleChatCompletionsClient()
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Tests/ChatCompletions/ChatCompletionsRequestTests.swift
+++ b/Tests/ChatCompletions/ChatCompletionsRequestTests.swift
@@ -1,0 +1,346 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AwsCommonRuntimeKit
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+@Suite("ChatCompletions Request Tests")
+struct ChatCompletionsRequestTests {
+
+    // MARK: - ChatCompletionsRequestBody encodes required fields correctly
+
+    @Test("Request body encodes model field correctly")
+    func encodesModelField() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: 8192,
+            messages: [ChatCompletionsMessage(role: .user, content: "Hello")],
+            service_tier: "default",
+            temperature: nil,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["model"] as? String == "google.gemma-4-31b")
+    }
+
+    @Test("Request body encodes max_completion_tokens field correctly")
+    func encodesMaxCompletionTokensField() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: 4096,
+            messages: [ChatCompletionsMessage(role: .user, content: "Hello")],
+            service_tier: "default",
+            temperature: nil,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["max_completion_tokens"] as? Int == 4096)
+    }
+
+    @Test("Request body encodes messages field correctly")
+    func encodesMessagesField() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: 8192,
+            messages: [
+                ChatCompletionsMessage(role: .user, content: "What is Swift?")
+            ],
+            service_tier: "default",
+            temperature: nil,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        let messages = try #require(json["messages"] as? [[String: String]])
+        #expect(messages.count == 1)
+        #expect(messages[0]["role"] == "user")
+        #expect(messages[0]["content"] == "What is Swift?")
+    }
+
+    @Test("Request body encodes service_tier field correctly")
+    func encodesServiceTierField() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: 8192,
+            messages: [ChatCompletionsMessage(role: .user, content: "Hello")],
+            service_tier: "priority",
+            temperature: nil,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["service_tier"] as? String == "priority")
+    }
+
+    // MARK: - Default service tier is "default" when not specified
+
+    @Test("Default service tier value is 'default'")
+    func defaultServiceTierIsDefault() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: 8192,
+            messages: [ChatCompletionsMessage(role: .user, content: "Hello")],
+            service_tier: "default",
+            temperature: nil,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["service_tier"] as? String == "default")
+    }
+
+    // MARK: - Optional temperature and top_p fields are omitted when nil
+
+    @Test("Temperature is omitted from JSON when nil")
+    func temperatureOmittedWhenNil() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: 8192,
+            messages: [ChatCompletionsMessage(role: .user, content: "Hello")],
+            service_tier: "default",
+            temperature: nil,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["temperature"] == nil)
+    }
+
+    @Test("top_p is omitted from JSON when nil")
+    func topPOmittedWhenNil() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: 8192,
+            messages: [ChatCompletionsMessage(role: .user, content: "Hello")],
+            service_tier: "default",
+            temperature: nil,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["top_p"] == nil)
+    }
+
+    @Test("Temperature is present in JSON when set")
+    func temperaturePresentWhenSet() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: 8192,
+            messages: [ChatCompletionsMessage(role: .user, content: "Hello")],
+            service_tier: "default",
+            temperature: 0.7,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["temperature"] as? Double == 0.7)
+    }
+
+    @Test("top_p is present in JSON when set")
+    func topPPresentWhenSet() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: 8192,
+            messages: [ChatCompletionsMessage(role: .user, content: "Hello")],
+            service_tier: "default",
+            temperature: nil,
+            top_p: 0.9
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["top_p"] as? Double == 0.9)
+    }
+
+    // MARK: - ChatCompletionsMessage serialization with role and content
+
+    @Test("ChatCompletionsMessage encodes role and content")
+    func messageEncodesRoleAndContent() throws {
+        let message = ChatCompletionsMessage(role: .assistant, content: "Hi there!")
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(message)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        #expect(json["role"] as? String == "assistant")
+        #expect(json["content"] as? String == "Hi there!")
+    }
+
+    @Test("Multiple messages serialize correctly in request body")
+    func multipleMessagesSerializeCorrectly() throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-3-27b-it",
+            max_completion_tokens: 2048,
+            messages: [
+                ChatCompletionsMessage(role: .system, content: "You are helpful."),
+                ChatCompletionsMessage(role: .user, content: "Hello"),
+            ],
+            service_tier: "default",
+            temperature: 1.0,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        let messages = try #require(json["messages"] as? [[String: String]])
+        #expect(messages.count == 2)
+        #expect(messages[0]["role"] == "system")
+        #expect(messages[0]["content"] == "You are helpful.")
+        #expect(messages[1]["role"] == "user")
+        #expect(messages[1]["content"] == "Hello")
+    }
+
+    // MARK: - Property-Based Tests
+
+    // Feature: gemma4-model-support, Property 3: Request serialization contains required fields
+    // Validates: Requirements 10.2, 11.2
+    @Test(
+        "Request serialization always contains required fields",
+        arguments: ChatCompletionsRequestTests.randomRequestInputs
+    )
+    func requestSerializationContainsRequiredFields(input: (prompt: String, maxTokens: Int)) throws {
+        let body = ChatCompletionsRequestBody(
+            model: "google.gemma-4-31b",
+            max_completion_tokens: input.maxTokens,
+            messages: [ChatCompletionsMessage(role: .user, content: input.prompt)],
+            service_tier: "default",
+            temperature: nil,
+            top_p: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(body)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["model"] != nil, "JSON must contain 'model' key")
+        #expect(json["max_completion_tokens"] != nil, "JSON must contain 'max_completion_tokens' key")
+        #expect(json["messages"] != nil, "JSON must contain 'messages' key")
+        #expect(json["service_tier"] != nil, "JSON must contain 'service_tier' key")
+    }
+
+    /// Generates 100 random (prompt, maxTokens) pairs for property testing.
+    static let randomRequestInputs: [(prompt: String, maxTokens: Int)] = {
+        let alphanumeric = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var inputs: [(String, Int)] = []
+        for _ in 0..<100 {
+            let length = Int.random(in: 1...500)
+            let prompt = String((0..<length).map { _ in alphanumeric.randomElement()! })
+            let maxTokens = Int.random(in: 1...8192)
+            inputs.append((prompt, maxTokens))
+        }
+        return inputs
+    }()
+
+    // Feature: gemma4-model-support, Property 4: Unsupported parameter combinations throw errors
+    // Validates: Requirements 10.4, 10.5, 11.3, 11.4, 20.4, 20.5
+
+    @Test(
+        "Both temperature and topP provided throws notSupported",
+        arguments: ChatCompletionsRequestTests.randomTemperatureTopPPairs
+    )
+    func bothTemperatureAndTopPThrows(pair: (temperature: Double, topP: Double)) async throws {
+        CommonRuntimeKit.initialize()
+        let bedrock = try await BedrockService(
+            region: .useast1,
+            bedrockClient: MockBedrockClient(),
+            bedrockRuntimeClient: MockBedrockRuntimeClient()
+        )
+
+        await #expect(throws: BedrockLibraryError.self) {
+            _ = try await bedrock.completeChatCompletion(
+                "Hello",
+                with: .gemma4_31b,
+                temperature: pair.temperature,
+                topP: pair.topP,
+                authentication: .apiKey(key: "test-key"),
+                mantleClient: MockBedrockMantleChatCompletionsClient()
+            )
+        }
+    }
+
+    @Test(
+        "TopK provided throws notSupported for Gemma 3",
+        arguments: ChatCompletionsRequestTests.randomTopKValues
+    )
+    func topKThrowsForGemma3(topK: Int) async throws {
+        CommonRuntimeKit.initialize()
+        let bedrock = try await BedrockService(
+            region: .useast1,
+            bedrockClient: MockBedrockClient(),
+            bedrockRuntimeClient: MockBedrockRuntimeClient()
+        )
+
+        await #expect(throws: BedrockLibraryError.self) {
+            let _: TextCompletion = try await bedrock.completeText(
+                "Hello",
+                with: .gemma3_27b_it,
+                topK: topK
+            )
+        }
+    }
+
+    /// Generates 100 random (temperature, topP) pairs where both are non-nil.
+    static let randomTemperatureTopPPairs: [(temperature: Double, topP: Double)] = {
+        var pairs: [(Double, Double)] = []
+        for _ in 0..<100 {
+            let temperature = Double.random(in: 0...2)
+            let topP = Double.random(in: 0...1)
+            pairs.append((temperature, topP))
+        }
+        return pairs
+    }()
+
+    /// Generates 100 random non-nil topK values.
+    static let randomTopKValues: [Int] = {
+        var values: [Int] = []
+        for _ in 0..<100 {
+            values.append(Int.random(in: 1...100))
+        }
+        return values
+    }()
+}

--- a/Tests/ChatCompletions/ChatCompletionsResponseTests.swift
+++ b/Tests/ChatCompletions/ChatCompletionsResponseTests.swift
@@ -1,0 +1,257 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+@Suite("ChatCompletions Response Tests")
+struct ChatCompletionsResponseTests {
+
+    // MARK: - Successful decoding of a valid Chat Completions JSON response
+
+    @Test("Decodes a valid Chat Completions JSON response")
+    func decodesValidResponse() throws {
+        let json = """
+            {
+                "id": "chatcmpl-abc123",
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "message": {"content": "Hello, world!", "role": "assistant"}
+                    }
+                ],
+                "created": 1234567890,
+                "model": "google.gemma-4-31b",
+                "object": "chat.completion",
+                "usage": {"completion_tokens": 5, "prompt_tokens": 10, "total_tokens": 15}
+            }
+            """
+        let data = try #require(json.data(using: .utf8))
+        let raw = try JSONDecoder().decode(ChatCompletionsRawOutput.self, from: data)
+        let output = try ChatCompletionsOutput(from: raw)
+
+        #expect(output.id == "chatcmpl-abc123")
+        #expect(output.model == "google.gemma-4-31b")
+        #expect(output.text == "Hello, world!")
+        #expect(output.usage.promptTokens == 10)
+        #expect(output.usage.completionTokens == 5)
+        #expect(output.usage.totalTokens == 15)
+    }
+
+    // MARK: - Text field is extracted from first choices[0].message.content
+
+    @Test("Text is extracted from first choice message content")
+    func textExtractedFromFirstChoice() throws {
+        let json = """
+            {
+                "id": "chatcmpl-xyz789",
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "message": {"content": "First choice content", "role": "assistant"}
+                    },
+                    {
+                        "finish_reason": "stop",
+                        "index": 1,
+                        "message": {"content": "Second choice content", "role": "assistant"}
+                    }
+                ],
+                "created": 1234567890,
+                "model": "google.gemma-4-26b-a4b",
+                "object": "chat.completion",
+                "usage": {"completion_tokens": 20, "prompt_tokens": 8, "total_tokens": 28}
+            }
+            """
+        let data = try #require(json.data(using: .utf8))
+        let raw = try JSONDecoder().decode(ChatCompletionsRawOutput.self, from: data)
+        let output = try ChatCompletionsOutput(from: raw)
+
+        #expect(output.text == "First choice content")
+    }
+
+    // MARK: - Empty choices array throws completionNotFound
+
+    @Test("Empty choices array throws completionNotFound")
+    func emptyChoicesThrowsCompletionNotFound() throws {
+        let json = """
+            {
+                "id": "chatcmpl-empty",
+                "choices": [],
+                "created": 1234567890,
+                "model": "google.gemma-4-31b",
+                "object": "chat.completion",
+                "usage": {"completion_tokens": 0, "prompt_tokens": 10, "total_tokens": 10}
+            }
+            """
+        let data = try #require(json.data(using: .utf8))
+        let raw = try JSONDecoder().decode(ChatCompletionsRawOutput.self, from: data)
+
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try ChatCompletionsOutput(from: raw)
+        }
+    }
+
+    // MARK: - Invalid JSON throws a decoding error
+
+    @Test("Invalid JSON throws a decoding error")
+    func invalidJSONThrowsDecodingError() throws {
+        let invalidJSON = "{ not valid json at all }"
+        let data = try #require(invalidJSON.data(using: .utf8))
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(ChatCompletionsRawOutput.self, from: data)
+        }
+    }
+
+    @Test("Missing required field throws a decoding error")
+    func missingFieldThrowsDecodingError() throws {
+        let json = """
+            {
+                "id": "chatcmpl-abc123",
+                "choices": [],
+                "created": 1234567890,
+                "object": "chat.completion",
+                "usage": {"completion_tokens": 0, "prompt_tokens": 10, "total_tokens": 10}
+            }
+            """
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(ChatCompletionsRawOutput.self, from: data)
+        }
+    }
+
+    // MARK: - OpenAIResponseBody decoding for Gemma 3 InvokeModel responses
+
+    @Test("OpenAIResponseBody decodes Gemma 3 InvokeModel response and extracts completion text")
+    func openAIResponseBodyDecodesGemma3Response() throws {
+        let json = """
+            {
+                "id": "chatcmpl-gemma3",
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "message": {"content": "Gemma 3 generated text", "role": "assistant"}
+                    }
+                ],
+                "created": 1234567890,
+                "model": "google.gemma-3-27b-it",
+                "object": "chat.completion",
+                "usage": {"completion_tokens": 12, "prompt_tokens": 5, "total_tokens": 17}
+            }
+            """
+        let data = try #require(json.data(using: .utf8))
+        let responseBody = try JSONDecoder().decode(OpenAIResponseBody.self, from: data)
+        let textCompletion = try responseBody.getTextCompletion()
+
+        #expect(textCompletion.completion == "Gemma 3 generated text")
+    }
+
+    @Test("OpenAIResponseBody with empty choices throws completionNotFound")
+    func openAIResponseBodyEmptyChoicesThrows() throws {
+        let json = """
+            {
+                "id": "chatcmpl-empty",
+                "choices": [],
+                "created": 1234567890,
+                "model": "google.gemma-3-12b-it",
+                "object": "chat.completion",
+                "usage": {"completion_tokens": 0, "prompt_tokens": 5, "total_tokens": 5}
+            }
+            """
+        let data = try #require(json.data(using: .utf8))
+        let responseBody = try JSONDecoder().decode(OpenAIResponseBody.self, from: data)
+
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try responseBody.getTextCompletion()
+        }
+    }
+
+    // MARK: - Property-Based Tests
+
+    // Feature: gemma4-model-support, Property 5: Response parsing preserves content text
+    // Validates: Requirements 12.1, 12.2
+    @Test(
+        "Response parsing preserves content text across random inputs",
+        arguments: ChatCompletionsResponseTests.randomContentStrings
+    )
+    func responseParsingPreservesContentText(content: String) throws {
+        let json = """
+            {
+                "id": "chatcmpl-xxx",
+                "choices": [{"finish_reason": "stop", "index": 0, "message": {"content": "\(content)", "role": "assistant"}}],
+                "created": 1234567890,
+                "model": "google.gemma-4-31b",
+                "object": "chat.completion",
+                "usage": {"completion_tokens": 10, "prompt_tokens": 5, "total_tokens": 15}
+            }
+            """
+        let data = try #require(json.data(using: .utf8))
+        let raw = try JSONDecoder().decode(ChatCompletionsRawOutput.self, from: data)
+        let output = try ChatCompletionsOutput(from: raw)
+
+        #expect(output.text == content)
+    }
+
+    // Feature: gemma4-model-support, Property 6: InvokeModel response parsing preserves content
+    // Validates: Requirements 16.5, 20.1, 20.2
+    @Test(
+        "InvokeModel response parsing preserves content text (Gemma 3)",
+        arguments: ChatCompletionsResponseTests.randomContentStrings
+    )
+    func invokeModelResponseParsingPreservesContentTextGemma3(content: String) throws {
+        let json = """
+            {
+                "id": "chatcmpl-xxx",
+                "choices": [{"finish_reason": "stop", "index": 0, "message": {"content": "\(content)", "role": "assistant"}}],
+                "created": 1234567890,
+                "model": "google.gemma-3-27b-it",
+                "object": "chat.completion",
+                "usage": {"completion_tokens": 10, "prompt_tokens": 5, "total_tokens": 15}
+            }
+            """
+        let data = try #require(json.data(using: .utf8))
+        let gemma3 = Gemma3Text(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 2, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+        let responseBody = try gemma3.getTextResponseBody(from: data)
+        let textCompletion = try responseBody.getTextCompletion()
+        #expect(textCompletion.completion == content)
+    }
+
+    /// Generates 100 random alphanumeric content strings (1–200 chars) for property testing.
+    static let randomContentStrings: [String] = {
+        let alphanumeric = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var strings: [String] = []
+        for _ in 0..<100 {
+            let length = Int.random(in: 1...200)
+            let content = String((0..<length).map { _ in alphanumeric.randomElement()! })
+            strings.append(content)
+        }
+        return strings
+    }()
+}

--- a/Tests/ChatCompletions/ChatCompletionsServiceTests.swift
+++ b/Tests/ChatCompletions/ChatCompletionsServiceTests.swift
@@ -1,0 +1,148 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AwsCommonRuntimeKit
+import Testing
+
+@testable import BedrockService
+
+@Suite("Chat Completions Service Tests")
+struct ChatCompletionsServiceTests {
+    let bedrock: BedrockService
+
+    init() async throws {
+        CommonRuntimeKit.initialize()
+        self.bedrock = try await BedrockService(
+            region: .useast1,
+            bedrockClient: MockBedrockClient(),
+            bedrockRuntimeClient: MockBedrockRuntimeClient()
+        )
+    }
+
+    // MARK: - completeChatCompletion
+
+    @Test("completeChatCompletion with Gemma 4 model returns correct output")
+    func completeChatCompletionGemma4() async throws {
+        let output = try await bedrock.completeChatCompletion(
+            "Hello from Gemma 4",
+            with: .gemma4_31b,
+            authentication: .apiKey(key: "test-key"),
+            mantleClient: MockBedrockMantleChatCompletionsClient()
+        )
+
+        #expect(output.text == "Mock completion for: Hello from Gemma 4")
+        #expect(output.model == "google.gemma-4-31b")
+        #expect(output.id == "chatcmpl-mock")
+        #expect(output.usage.promptTokens == 5)
+        #expect(output.usage.completionTokens == 10)
+        #expect(output.usage.totalTokens == 15)
+    }
+
+    @Test("completeChatCompletion with Gemma 3 model returns correct output")
+    func completeChatCompletionGemma3() async throws {
+        let output = try await bedrock.completeChatCompletion(
+            "Hello from Gemma 3",
+            with: .gemma3_27b_it,
+            authentication: .apiKey(key: "test-key"),
+            mantleClient: MockBedrockMantleChatCompletionsClient()
+        )
+
+        #expect(output.text == "Mock completion for: Hello from Gemma 3")
+        #expect(output.model == "google.gemma-3-27b-it")
+        #expect(output.id == "chatcmpl-mock")
+        #expect(output.usage.promptTokens == 5)
+        #expect(output.usage.completionTokens == 10)
+        #expect(output.usage.totalTokens == 15)
+    }
+
+    @Test("completeChatCompletion throws invalidModality for model without ChatCompletionsModality")
+    func completeChatCompletionThrowsForInvalidModel() async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            _ = try await bedrock.completeChatCompletion(
+                "Hello",
+                with: .nova_micro,
+                authentication: .apiKey(key: "test-key"),
+                mantleClient: MockBedrockMantleChatCompletionsClient()
+            )
+        }
+    }
+
+    @Test("completeChatCompletion throws notSupported when both temperature and topP are provided")
+    func completeChatCompletionThrowsForBothTemperatureAndTopP() async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            _ = try await bedrock.completeChatCompletion(
+                "Hello",
+                with: .gemma4_31b,
+                temperature: 0.5,
+                topP: 0.9,
+                authentication: .apiKey(key: "test-key"),
+                mantleClient: MockBedrockMantleChatCompletionsClient()
+            )
+        }
+    }
+
+    // MARK: - createResponse (Responses API with Gemma 4)
+
+    @Test("createResponse with Gemma 4 model works via Responses API")
+    func createResponseGemma4() async throws {
+        let output = try await bedrock.createResponse(
+            "Tell me about Gemma 4",
+            with: .gemma4_31b,
+            authentication: .apiKey(key: "test-key"),
+            mantleClient: MockBedrockMantleClient()
+        )
+
+        #expect(output.text == "Mock response for: Tell me about Gemma 4")
+        #expect(output.model == .gemma4_31b)
+        #expect(output.id == "resp_mock_123")
+        #expect(output.usage.inputTokens == 10)
+        #expect(output.usage.outputTokens == 20)
+    }
+
+    // MARK: - completeText (InvokeModel with Gemma 3)
+
+    @Test("completeText with Gemma 3 model via InvokeModel works")
+    func completeTextGemma3() async throws {
+        let completion: TextCompletion = try await bedrock.completeText(
+            "Hello Gemma 3",
+            with: .gemma3_27b_it
+        )
+
+        #expect(completion.completion == "Mock response for: Hello Gemma 3")
+    }
+
+    @Test("completeText with Gemma 3 throws when both temperature and topP provided")
+    func completeTextGemma3ThrowsForBothTemperatureAndTopP() async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _: TextCompletion = try await bedrock.completeText(
+                "Hello",
+                with: .gemma3_27b_it,
+                temperature: 0.5,
+                topP: 0.9
+            )
+        }
+    }
+
+    @Test("completeText with Gemma 3 throws when topK is provided")
+    func completeTextGemma3ThrowsForTopK() async throws {
+        await #expect(throws: BedrockLibraryError.self) {
+            let _: TextCompletion = try await bedrock.completeText(
+                "Hello",
+                with: .gemma3_27b_it,
+                topK: 10
+            )
+        }
+    }
+}

--- a/Tests/Mock/MockBedrockMantleChatCompletionsClient.swift
+++ b/Tests/Mock/MockBedrockMantleChatCompletionsClient.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+@testable import BedrockService
+
+public struct MockBedrockMantleChatCompletionsClient: BedrockMantleClientProtocol {
+    public init() {}
+
+    public func sendRequest(
+        body: Data,
+        url: URL,
+        authentication: BedrockMantleAuthentication
+    ) async throws -> Data {
+        guard let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+            let model = json["model"] as? String,
+            let messages = json["messages"] as? [[String: Any]],
+            let lastMessage = messages.last,
+            let content = lastMessage["content"] as? String
+        else {
+            throw BedrockLibraryError.invalidSDKResponse("Invalid request body")
+        }
+
+        let response = """
+            {
+                "id": "chatcmpl-mock",
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "message": {
+                            "content": "Mock completion for: \(content)",
+                            "role": "assistant"
+                        }
+                    }
+                ],
+                "created": 1234567890,
+                "model": "\(model)",
+                "object": "chat.completion",
+                "usage": {
+                    "completion_tokens": 10,
+                    "prompt_tokens": 5,
+                    "total_tokens": 15
+                }
+            }
+            """
+        return response.data(using: .utf8)!
+    }
+}

--- a/Tests/Mock/MockBedrockRuntimeClient.swift
+++ b/Tests/Mock/MockBedrockRuntimeClient.swift
@@ -194,6 +194,8 @@ public struct MockBedrockRuntimeClient: BedrockRuntimeClientProtocol {
             return InvokeModelOutput(body: try invokeTitanModel(body: inputBody))
         case "Anthropic Text Generation":
             return InvokeModelOutput(body: try invokeAnthropicModel(body: inputBody))
+        case "Gemma 3 Text Generation":
+            return InvokeModelOutput(body: try invokeGemma3Model(body: inputBody))
         default:
             throw AWSBedrockRuntime.ValidationException(
                 message: "Malformed input request, please reformat your input and try again."
@@ -358,6 +360,39 @@ public struct MockBedrockRuntimeClient: BedrockRuntimeClientProtocol {
                     "usage":{
                         "input_tokens":12,
                         "output_tokens":100}
+                }
+                """.data(using: .utf8)!
+        } else {
+            throw AWSBedrockRuntime.ValidationException(
+                message: "Malformed input request, please reformat your input and try again."
+            )
+        }
+    }
+
+    private func invokeGemma3Model(body: Data) throws -> Data? {
+        guard
+            let json: [String: Any] = try? JSONSerialization.jsonObject(
+                with: body,
+                options: []
+            )
+                as? [String: Any]
+        else {
+            throw AWSBedrockRuntime.ValidationException(
+                message: "Malformed input request, please reformat your input and try again."
+            )
+        }
+        if let messages = json["messages"] as? [[String: Any]],
+            let lastMessage = messages.last,
+            let inputText = lastMessage["content"] as? String
+        {
+            return """
+                {
+                    "id": "chatcmpl-mock",
+                    "choices": [{"finish_reason": "stop", "index": 0, "message": {"content": "Mock response for: \(inputText)", "role": "assistant"}}],
+                    "created": 1234567890,
+                    "model": "google.gemma-3-27b-it",
+                    "object": "chat.completion",
+                    "usage": {"completion_tokens": 10, "prompt_tokens": 5, "total_tokens": 15}
                 }
                 """.data(using: .utf8)!
         } else {


### PR DESCRIPTION
## Summary

Adds all six Google Gemma models to the Swift Bedrock Library.

**Gemma 4 (mantle-only):** gemma4_31b, gemma4_26b_a4b, gemma4_e2b
**Gemma 3 (dual-endpoint):** gemma3_27b_it, gemma3_12b_it, gemma3_4b_it

## Changes

- New ChatCompletionsModality protocol
- completeChatCompletion service method (single-turn and multi-turn)
- ChatCompletionsRole enum with ergonomic array extensions
- Google provider directory with Gemma4Text and Gemma3Text modality structs
- 6 model constants with parameter validation
- DocC article for the Chat Completions API
- google-gemma example added to CI
- Comprehensive tests (320 passing)

## What was tested

- swift test: 320 tests in 29 suites, all passing
- swift build in Examples/google-gemma/: compiles cleanly