### PR TITLE
Extract shared bedrock-mantle URL and client helpers

### DIFF
--- a/Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/BedrockService+ChatCompletions.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/ChatCompletions/BedrockService+ChatCompletions.swift
@@ -144,22 +144,19 @@ extension BedrockService {
         let bodyData = try encoder.encode(requestBody)
 
         let path = modality.getChatCompletionsPath()
-        let urlString = "https://bedrock-mantle.\(region.rawValue).api.aws\(path)"
-        guard let url = URL(string: urlString, encodingInvalidCharacters: false) else {
-            throw BedrockLibraryError.invalidURI(urlString)
-        }
+        let url = try makeMantleURL(path: path)
 
         logger.trace(
             "Creating chat completion via bedrock-mantle",
             metadata: [
                 "model.id": .string(model.id),
-                "url": .string(urlString),
+                "url": .string(url.absoluteString),
             ]
         )
 
         let mantleAuth = try await resolveMantleAuthentication(authentication)
 
-        let client = mantleClient ?? BedrockMantleClient(region: region.rawValue, logger: self.logger)
+        let client = makeMantleClient(override: mantleClient)
         let responseData = try await client.sendRequest(
             body: bodyData,
             url: url,

--- a/Sources/BedrockService/BedrockRuntimeClient/Messages/BedrockService+Messages.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Messages/BedrockService+Messages.swift
@@ -79,22 +79,19 @@ extension BedrockService {
         let encoder = JSONEncoder()
         let bodyData = try encoder.encode(requestBody)
 
-        let urlString = "https://bedrock-mantle.\(region.rawValue).api.aws\(path)"
-        guard let url = URL(string: urlString, encodingInvalidCharacters: false) else {
-            throw BedrockLibraryError.invalidURI(urlString)
-        }
+        let url = try makeMantleURL(path: path)
 
         logger.trace(
             "Creating message via bedrock-mantle",
             metadata: [
                 "model.id": .string(model.id),
-                "url": .string(urlString),
+                "url": .string(url.absoluteString),
             ]
         )
 
         let mantleAuth = try await resolveMantleAuthentication(authentication)
 
-        let client = mantleClient ?? BedrockMantleClient(region: region.rawValue, logger: self.logger)
+        let client = makeMantleClient(override: mantleClient)
         let responseData = try await client.sendRequest(
             body: bodyData,
             url: url,

--- a/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockService+Responses.swift
+++ b/Sources/BedrockService/BedrockRuntimeClient/Responses/BedrockService+Responses.swift
@@ -52,22 +52,19 @@ extension BedrockService {
         let encoder = JSONEncoder()
         let bodyData = try encoder.encode(requestBody)
 
-        let urlString = "https://bedrock-mantle.\(region.rawValue).api.aws\(path)"
-        guard let url = URL(string: urlString, encodingInvalidCharacters: false) else {
-            throw BedrockLibraryError.invalidURI(urlString)
-        }
+        let url = try makeMantleURL(path: path)
 
         logger.trace(
             "Creating response via bedrock-mantle",
             metadata: [
                 "model.id": .string(model.id),
-                "url": .string(urlString),
+                "url": .string(url.absoluteString),
             ]
         )
 
         let mantleAuth = try await resolveMantleAuthentication(authentication)
 
-        let client = mantleClient ?? BedrockMantleClient(region: region.rawValue, logger: self.logger)
+        let client = makeMantleClient(override: mantleClient)
         let responseData = try await client.sendRequest(
             body: bodyData,
             url: url,

--- a/Sources/BedrockService/BedrockService+Mantle.swift
+++ b/Sources/BedrockService/BedrockService+Mantle.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension BedrockService {
+
+    /// Constructs a validated bedrock-mantle URL for the given path.
+    /// - Parameter path: The API path (e.g. `/anthropic/v1/messages`)
+    /// - Returns: A validated URL pointing to the bedrock-mantle endpoint
+    /// - Throws: `BedrockLibraryError.invalidURI` if the constructed URL string is invalid
+    package func makeMantleURL(path: String) throws -> URL {
+        let urlString = "https://bedrock-mantle.\(region.rawValue).api.aws\(path)"
+        guard let url = URL(string: urlString, encodingInvalidCharacters: false) else {
+            throw BedrockLibraryError.invalidURI(urlString)
+        }
+        return url
+    }
+
+    /// Returns the provided mantle client override, or creates a default one using the service's region and logger.
+    /// - Parameter mantleClient: An optional client override (typically used for testing)
+    /// - Returns: The override client if non-nil, otherwise a new `BedrockMantleClient`
+    package func makeMantleClient(override mantleClient: BedrockMantleClientProtocol?) -> BedrockMantleClientProtocol {
+        mantleClient ?? BedrockMantleClient(region: region.rawValue, logger: self.logger)
+    }
+}


### PR DESCRIPTION
## Summary

Reduces duplication across the three bedrock-mantle API extensions (Messages, Responses, ChatCompletions) by extracting two shared helpers into `BedrockService+Mantle.swift`:

- `makeMantleURL(path:)` — constructs and validates the bedrock-mantle URL
- `makeMantleClient(override:)` — returns the override or creates a default client

## Changes

- **New:** `Sources/BedrockService/BedrockService+Mantle.swift`
- **Modified:** `BedrockService+Messages.swift`, `BedrockService+Responses.swift`, `BedrockService+ChatCompletions.swift` — replaced inline URL/client construction with helper calls

## Testing

All 347 existing tests pass. No behavior change — pure refactoring.