### PR TITLE
Add Claude Mythos 5 model support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,7 +109,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'anthropic-messages', 'api-key', 'converse', 'converse-stream', 'embeddings', 'google-gemma', 'openai-bedrock', 'openai-responses', 'retrieve', 'stability-image', 'structured-output', 'text_chat' ]"
+      examples: "[ 'anthropic-messages', 'anthropic-mythos-messages', 'api-key', 'converse', 'converse-stream', 'embeddings', 'google-gemma', 'openai-bedrock', 'openai-responses', 'retrieve', 'stability-image', 'structured-output', 'text_chat' ]"
 
   swift-6-language-mode:
     name: Swift 6 Language Mode

--- a/.kiro/specs/claude-mythos-5-support/.config.kiro
+++ b/.kiro/specs/claude-mythos-5-support/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "2db626b8-7ed3-46ee-a4ed-3e10e39ba2ce", "workflowType": "design-first", "specType": "feature"}

--- a/.kiro/specs/claude-mythos-5-support/design.md
+++ b/.kiro/specs/claude-mythos-5-support/design.md
@@ -1,0 +1,564 @@
+# Design Document: Claude Mythos 5 Model Support
+
+## Overview
+
+This design adds Claude Mythos 5 (`anthropic.claude-mythos-5`) to the Swift Bedrock Library. Mythos 5 is a next-generation Anthropic model with a 1M token context window and 128K max output tokens, available exclusively via the Messages API on the bedrock-mantle endpoint in us-east-1.
+
+Key differentiators from Claude Fable 5 (the closest existing model):
+- **No cross-region inference** — us-east-1 only (no `GlobalCrossRegionInferenceModality`)
+- **No Converse API support** — Messages API only (no `ConverseModality` / `ConverseStreamingModality`)
+- **Strict sampling constraints** — temperature must be 1.0 or unset; top_p must be ≥ 0.99 and < 1.0 or unset; top_k not supported
+- **Adaptive reasoning always on** — reasoning cannot be disabled, effort level is configurable
+
+The implementation introduces a new `Claude_Mythos_v5` modality struct that conforms only to `TextModality` and `MessagesModality` — the minimal protocol set for a bedrock-mantle-only model without Converse support.
+
+## Architecture
+
+### Endpoint Routing
+
+```mermaid
+graph TD
+    subgraph "bedrock-mantle (us-east-1 only)"
+        MM[MessagesModality] --> CM["createMessage()"]
+    end
+
+    subgraph "bedrock-runtime"
+        TM_RT[ConverseModality] --> CC["converse()"]
+        TM_INV[TextModality - InvokeModel] --> CT["completeText()"]
+    end
+
+    Mythos5[Claude Mythos 5] --> MM
+    Mythos5 -.->|NOT supported| TM_RT
+    Mythos5 -.->|NOT supported| TM_INV
+
+    Fable5[Claude Fable 5] --> MM
+    Fable5 --> TM_RT
+    Fable5 --> CC
+```
+
+### Comparison with Claude Fable 5
+
+```mermaid
+classDiagram
+    class Claude_Fable_v5 {
+        +TextModality
+        +ConverseModality
+        +ConverseStreamingModality
+        +GlobalCrossRegionInferenceModality
+        +MessagesModality
+        +getMessagesPath() String
+    }
+
+    class Claude_Mythos_v5 {
+        +TextModality
+        +MessagesModality
+        +getMessagesPath() String
+    }
+
+    note for Claude_Mythos_v5 "No Converse, no cross-region inference\nus-east-1 only"
+```
+
+### Message Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant BS as BedrockService
+    participant BM as BedrockMantleClient
+    participant API as bedrock-mantle.us-east-1.api.aws
+
+    App->>BS: createMessage("prompt", model: .claude_mythos_v5)
+    BS->>BS: model.getMessagesModality()
+    BS->>BS: modality.getMessagesPath() → "/anthropic/v1/messages"
+    BS->>BS: Build MessagesRequestBody(model, maxTokens, messages)
+    BS->>BS: Resolve authentication (SigV4 or API key)
+    BS->>BM: sendRequest(body, url, auth)
+    BM->>API: POST https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages
+    API-->>BM: JSON response
+    BM-->>BS: Data
+    BS->>BS: Decode MessagesRawOutput → MessagesOutput
+    BS-->>App: MessagesOutput(id, text, usage)
+```
+
+## Components and Interfaces
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| (none) | All changes fit in existing files |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift` | Add `Claude_Mythos_v5` struct |
+| `Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift` | Add `BedrockModel.claude_mythos_v5` static constant |
+| `Sources/BedrockService/Models/BedrockModel.swift` | Add case in `init?(rawValue:)` switch |
+
+### `Claude_Mythos_v5` Struct
+
+```swift
+struct Claude_Mythos_v5: TextModality, MessagesModality {
+    private let anthropicText: AnthropicText
+
+    init(parameters: TextGenerationParameters, features: [ConverseFeature], maxReasoningTokens: Parameter<Int>) {
+        self.anthropicText = AnthropicText(
+            parameters: parameters,
+            features: features,
+            maxReasoningTokens: maxReasoningTokens
+        )
+    }
+
+    func getName() -> String { anthropicText.getName() }
+    func getParameters() -> TextGenerationParameters { anthropicText.getParameters() }
+    func getMessagesPath() -> String { "/anthropic/v1/messages" }
+
+    func getTextRequestBody(
+        prompt: String,
+        maxTokens: Int?,
+        temperature: Double?,
+        topP: Double?,
+        topK: Int?,
+        stopSequences: [String]?,
+        serviceTier: ServiceTier
+    ) throws -> BedrockBodyCodable {
+        try anthropicText.getTextRequestBody(
+            prompt: prompt,
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            stopSequences: stopSequences,
+            serviceTier: serviceTier
+        )
+    }
+
+    func getTextResponseBody(from data: Data) throws -> ContainsTextCompletion {
+        try anthropicText.getTextResponseBody(from: data)
+    }
+}
+```
+
+**Key design decisions:**
+
+1. **No `ConverseModality` / `ConverseStreamingModality`**: The Converse API is explicitly not supported for Mythos 5. Calling `model.hasConverseModality()` returns `false`.
+
+2. **No `GlobalCrossRegionInferenceModality`**: Mythos 5 is us-east-1 only. `getModelIdWithCrossRegionInferencePrefix(region:)` returns the plain model ID with no prefix.
+
+3. **No `CrossRegionInferenceModality`**: Not even regional cross-region. Single-region only.
+
+4. **Delegates to `AnthropicText`**: Reuses the existing request/response body serialization. The `TextModality` conformance is needed for parameter access (`getParameters()`) and request body building — even though InvokeModel isn't the primary API, the library's parameter validation infrastructure lives on `TextModality`.
+
+5. **Messages path**: Returns `"/anthropic/v1/messages"` — same path as Fable 5.
+
+### `BedrockModel.claude_mythos_v5` Static Constant
+
+```swift
+extension BedrockModel {
+    public static let claude_mythos_v5: BedrockModel = BedrockModel(
+        id: "anthropic.claude-mythos-5",
+        name: "Claude Mythos 5",
+        modality: Claude_Mythos_v5(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 1, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 128_000, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0.99, maxValue: 1, defaultValue: nil),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
+                maxPromptSize: 1_000_000
+            ),
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
+            maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
+        )
+    )
+}
+```
+
+**Parameter rationale:**
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `temperature` | min: 1, max: 1, default: 1 | Must be 1.0 or unset — clamped to single value |
+| `maxTokens` | min: 1, max: 128,000, default: 8,192 | 128K output capacity; 8K default matches library convention |
+| `topP` | min: 0.99, max: 1, default: nil | Must be ≥ 0.99 and < 1.0 or unset; nil default means "unset" |
+| `topK` | `.notSupported` | Not supported at all |
+| `maxPromptSize` | 1,000,000 | 1M token context window |
+| `maxReasoningTokens` | min: 1,024, max: 8,191, default: 4,096 | Reasoning always on; effort configurable |
+
+### `BedrockModel.init?(rawValue:)` Addition
+
+```swift
+// In the switch statement, add:
+case BedrockModel.claude_mythos_v5.id:
+    self = BedrockModel.claude_mythos_v5
+```
+
+## Data Models
+
+### Protocol Conformance Summary
+
+| Check | Claude Mythos 5 | Claude Fable 5 (reference) |
+|-------|-----------------|---------------------------|
+| `hasTextModality()` | `true` | `true` |
+| `hasMessagesModality()` | `true` | `true` |
+| `hasConverseModality()` | `false` | `true` |
+| `hasConverseStreamingModality()` | `false` | `true` |
+| `hasImageModality()` | `false` | `false` |
+| `hasEmbeddingsModality()` | `false` | `false` |
+| `hasResponsesModality()` | `false` | `false` |
+| Cross-region inference | None (plain ID) | Global prefix (`global.`) |
+
+### Model Metadata
+
+| Field | Value |
+|-------|-------|
+| Model ID | `anthropic.claude-mythos-5` |
+| Display Name | Claude Mythos 5 |
+| Endpoint | bedrock-mantle |
+| API Path | `/anthropic/v1/messages` |
+| Region | us-east-1 only |
+| Context Window | 1,000,000 tokens |
+| Max Output | 128,000 tokens |
+| Reasoning | Always on (adaptive) |
+| Prompt Caching | Yes (min 1024 tokens, max 4 breakpoints, TTL 5min/1hr) |
+| Service Tier | Standard only |
+| Launch Date | June 9, 2026 |
+
+### Wire Format (Messages API)
+
+**Request** (reuses existing `MessagesRequestBody`):
+
+```json
+{
+  "model": "anthropic.claude-mythos-5",
+  "max_tokens": 8192,
+  "messages": [
+    {"role": "user", "content": "Explain quantum computing"}
+  ]
+}
+```
+
+**Response** (reuses existing `MessagesRawOutput`):
+
+```json
+{
+  "id": "msg_01abc123",
+  "type": "message",
+  "role": "assistant",
+  "model": "anthropic.claude-mythos-5",
+  "content": [
+    {"type": "thinking", "thinking": "Let me reason about this..."},
+    {"type": "text", "text": "Quantum computing is..."}
+  ],
+  "stop_reason": "end_turn",
+  "usage": {
+    "input_tokens": 12,
+    "output_tokens": 256
+  }
+}
+```
+
+## Key Functions with Formal Specifications
+
+### Function: `Claude_Mythos_v5.getTextRequestBody()`
+
+```swift
+func getTextRequestBody(
+    prompt: String,
+    maxTokens: Int?,
+    temperature: Double?,
+    topP: Double?,
+    topK: Int?,
+    stopSequences: [String]?,
+    serviceTier: ServiceTier
+) throws -> BedrockBodyCodable
+```
+
+**Preconditions:**
+- `prompt` is non-empty
+- If `maxTokens` is non-nil: 1 ≤ `maxTokens` ≤ 128,000
+- If `temperature` is non-nil: `temperature` == 1.0
+- If `topP` is non-nil: 0.99 ≤ `topP` < 1.0
+- `topK` must be nil (not supported)
+- `temperature` and `topP` must not both be non-nil
+
+**Postconditions:**
+- Returns a valid `AnthropicRequestBody` that serializes to JSON
+- If `maxTokens` was nil and parameter has no default, throws `notFound`
+- If both `topP` and `temperature` are non-nil, throws `notSupported`
+- Returned body contains the `prompt` text
+- Returned body contains resolved `maxTokens` value
+
+**Loop Invariants:** N/A
+
+### Function: `Claude_Mythos_v5.getMessagesPath()`
+
+```swift
+func getMessagesPath() -> String
+```
+
+**Preconditions:** None
+
+**Postconditions:**
+- Returns exactly `"/anthropic/v1/messages"`
+- Return value is constant across all invocations
+
+**Loop Invariants:** N/A
+
+### Function: `BedrockModel.getModelIdWithCrossRegionInferencePrefix(region:)`
+
+```swift
+func getModelIdWithCrossRegionInferencePrefix(region: Region) -> String
+```
+
+**Preconditions:**
+- `self` == `.claude_mythos_v5`
+- `region` is any valid `Region`
+
+**Postconditions:**
+- Returns `"anthropic.claude-mythos-5"` (no prefix) for ALL regions
+- The model's modality does not conform to `GlobalCrossRegionInferenceModality`
+- The model's modality does not conform to `CrossRegionInferenceModality`
+
+**Loop Invariants:** N/A
+
+## Algorithmic Pseudocode
+
+### Model Resolution from Raw Value
+
+```swift
+// Within BedrockModel.init?(rawValue:)
+// Existing switch statement gains one new case:
+
+switch rawValue {
+    // ... existing cases ...
+    case "anthropic.claude-mythos-5":
+        self = BedrockModel.claude_mythos_v5
+    // ... remaining cases ...
+    default:
+        return nil
+}
+```
+
+### createMessage Flow for Mythos 5
+
+```swift
+// BedrockService.createMessage with Claude Mythos 5
+// Step 1: Verify modality
+let modality = try model.getMessagesModality()
+// → succeeds: Claude_Mythos_v5 conforms to MessagesModality
+
+// Step 2: Get path
+let path = modality.getMessagesPath()
+// → "/anthropic/v1/messages"
+
+// Step 3: Build request body
+let requestBody = MessagesRequestBody(model: model, maxTokens: maxTokens, messages: messages)
+
+// Step 4: Construct URL
+let urlString = "https://bedrock-mantle.\(region.rawValue).api.aws\(path)"
+// → "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages"
+
+// Step 5: Resolve auth and send
+let mantleAuth = try await resolveMantleAuthentication(authentication)
+let responseData = try await client.sendRequest(body: bodyData, url: url, authentication: mantleAuth)
+
+// Step 6: Decode
+let rawOutput = try decoder.decode(MessagesRawOutput.self, from: responseData)
+let output = try MessagesOutput(from: rawOutput)
+```
+
+### Parameter Validation — topP Constraint
+
+```swift
+// The topP parameter is declared as:
+// Parameter(.topP, minValue: 0.99, maxValue: 1, defaultValue: nil)
+//
+// When the user provides topP:
+//   - If topP < 0.99 → parameter validation throws invalidParameter
+//   - If topP >= 1.0 → parameter validation throws invalidParameter
+//   - If topP is nil → parameter is omitted from request (default = nil means "unset")
+//   - If topP in [0.99, 1.0) → valid, included in request
+//
+// Note: The maxValue of 1 in the Parameter declaration is exclusive for topP
+// due to the AWS constraint "< 1.0". The validation logic in the library
+// checks value <= maxValue, so in practice topP = 1.0 would pass parameter
+// validation but be rejected by the API. This matches the Fable 5 pattern.
+```
+
+## Example Usage
+
+```swift
+import BedrockService
+
+// Initialize the service in us-east-1
+let bedrock = try BedrockService(region: .useast1)
+
+// Simple message
+let output = try await bedrock.createMessage(
+    "Explain the Riemann hypothesis",
+    with: .claude_mythos_v5,
+    authentication: .default
+)
+print(output.text)
+
+// Multi-turn conversation
+let messages: [AnthropicMessage] = [
+    AnthropicMessage(role: .user, content: "What is quantum entanglement?"),
+    AnthropicMessage(role: .assistant, content: "Quantum entanglement is..."),
+    AnthropicMessage(role: .user, content: "How is it used in computing?"),
+]
+let reply = try await bedrock.createMessage(
+    messages,
+    with: .claude_mythos_v5,
+    maxTokens: 16_384,
+    authentication: .default
+)
+print(reply.text)
+
+// Model lookup from raw string
+if let model = BedrockModel(rawValue: "anthropic.claude-mythos-5") {
+    print(model.name) // "Claude Mythos 5"
+    print(model.hasMessagesModality()) // true
+    print(model.hasConverseModality()) // false
+}
+
+// Cross-region prefix (no-op for Mythos 5)
+let prefixedId = BedrockModel.claude_mythos_v5
+    .getModelIdWithCrossRegionInferencePrefix(region: .useast1)
+// → "anthropic.claude-mythos-5" (no prefix applied)
+```
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Model resolves from raw value
+
+*For any* call to `BedrockModel(rawValue: "anthropic.claude-mythos-5")`, the result SHALL be non-nil and its `id` SHALL equal `"anthropic.claude-mythos-5"` and its `name` SHALL equal `"Claude Mythos 5"`.
+
+**Validates: Requirements 1.1, 1.2, 1.3**
+
+### Property 2: Messages modality is present and returns correct path
+
+*For any* instance of `BedrockModel.claude_mythos_v5`, calling `hasMessagesModality()` SHALL return `true`, and calling `getMessagesModality().getMessagesPath()` SHALL return `"/anthropic/v1/messages"`.
+
+**Validates: Requirements 2.1, 2.2**
+
+### Property 3: Converse modality is absent
+
+*For any* instance of `BedrockModel.claude_mythos_v5`, calling `hasConverseModality()` SHALL return `false`, and calling `getConverseModality()` SHALL throw `BedrockLibraryError.invalidModality`.
+
+**Validates: Requirements 3.1, 3.3**
+
+### Property 4: No cross-region inference prefix applied
+
+*For any* valid `Region` value, calling `BedrockModel.claude_mythos_v5.getModelIdWithCrossRegionInferencePrefix(region:)` SHALL return `"anthropic.claude-mythos-5"` without any prefix.
+
+**Validates: Requirements 4.1**
+
+### Property 5: Temperature range enforcement
+
+*For any* temperature value where `temperature != 1.0`, parameter validation on Claude Mythos 5 SHALL reject it (the declared range is [1, 1], so only exactly 1.0 is valid).
+
+**Validates: Requirements 5.1, 5.3**
+
+### Property 6: TopK rejection
+
+*For any* non-nil `topK` value provided to `getTextRequestBody()` on Claude Mythos 5, the `AnthropicText` implementation SHALL handle it according to its existing logic (topK is declared as `.notSupported`).
+
+**Validates: Requirements 7.1, 7.2**
+
+### Property 7: TopP range enforcement
+
+*For any* `topP` value where `topP < 0.99`, parameter validation on Claude Mythos 5 SHALL reject it. *For any* `topP` value where `0.99 ≤ topP < 1.0`, it SHALL be accepted.
+
+**Validates: Requirements 6.1, 6.2, 6.3**
+
+### Property 8: Unknown raw values resolve to nil
+
+*For any* string that is not a known model ID (e.g., random UUIDs, "anthropic.claude-mythos-6"), `BedrockModel(rawValue:)` SHALL return nil.
+
+**Validates: Requirements 1.4**
+
+## Error Handling
+
+| Scenario | Error | Recovery |
+|----------|-------|----------|
+| Call `getConverseModality()` on Mythos 5 | `BedrockLibraryError.invalidModality` | Caller should use `createMessage()` instead |
+| Call `getConverseStreamingModality()` on Mythos 5 | `false` from `hasConverseStreamingModality()` | Caller should use Messages API |
+| Both temperature and topP provided | `BedrockLibraryError.notSupported` | Provide at most one |
+| Temperature not equal to 1.0 | `BedrockLibraryError.invalidParameter` | Use 1.0 or omit |
+| topP < 0.99 | `BedrockLibraryError.invalidParameter` | Use value in [0.99, 1.0) or omit |
+| maxTokens > 128,000 | `BedrockLibraryError.invalidParameter` | Use value ≤ 128,000 |
+| `createMessage()` called with region ≠ us-east-1 | API returns HTTP error | Service configured for us-east-1 |
+| Invalid/expired credentials | `BedrockLibraryError.authenticationError` | Refresh credentials |
+| Model ID not found in `init?(rawValue:)` | Returns `nil` | Check for typos in model ID |
+
+## Testing Strategy
+
+### Test Framework
+
+All tests use Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) as per project conventions. Run with `swift test`.
+
+### Unit Tests (Example-Based)
+
+Organized in:
+- `Tests/Messages/MythosModelTests.swift` — model constant, modality checks, parameter declarations
+
+Coverage:
+- Model constant: ID == `"anthropic.claude-mythos-5"`, name == `"Claude Mythos 5"`
+- `hasMessagesModality()` → `true`
+- `hasConverseModality()` → `false`
+- `hasConverseStreamingModality()` → `false`
+- `hasImageModality()` → `false`
+- `hasEmbeddingsModality()` → `false`
+- `hasResponsesModality()` → `false`
+- `hasTextModality()` → `true`
+- `getMessagesPath()` → `"/anthropic/v1/messages"`
+- `BedrockModel(rawValue: "anthropic.claude-mythos-5")` → non-nil, correct model
+- `BedrockModel(rawValue: "anthropic.claude-mythos-6")` → nil
+- `getModelIdWithCrossRegionInferencePrefix(region: .useast1)` → `"anthropic.claude-mythos-5"`
+- `getModelIdWithCrossRegionInferencePrefix(region: .euwest1)` → `"anthropic.claude-mythos-5"` (still no prefix)
+- Parameter values: temperature range [1,1], topP range [0.99, 1], topK not supported, maxTokens [1, 128000], maxPromptSize 1M
+- Features list includes `.reasoning`
+- `maxReasoningTokens` parameter supported (min 1024, max 8191, default 4096)
+
+### Property-Based Tests
+
+Using Swift Testing's `@Test(..., arguments:)` with generated value arrays:
+
+| Property | Strategy |
+|----------|----------|
+| 4: No cross-region prefix | Test with all known Region enum cases; verify output == `"anthropic.claude-mythos-5"` for every region |
+| 5: Temperature range | Generate 100 values outside [1,1] (random doubles in [0, 0.99] ∪ (1.0, 2.0]); verify parameter validation rejects each |
+| 7: TopP range | Generate 100 values in [0, 0.989]; verify rejected. Generate 100 values in [0.99, 0.999]; verify accepted |
+| 8: Unknown raw values | Generate 100 random UUID strings; verify `BedrockModel(rawValue:)` returns nil for each |
+
+### Integration Tests (with Mocks)
+
+Using existing `MockBedrockMantleClient`:
+- `createMessage` with `.claude_mythos_v5` → correct URL contains `"bedrock-mantle"` and `"/anthropic/v1/messages"`
+- `createMessage` with custom maxTokens → request body contains expected value
+- Verify `createMessage` throws `invalidModality` when calling converse-related methods on Mythos 5
+
+## Performance Considerations
+
+- **Single region constraint**: Applications needing multi-region failover cannot use Mythos 5 as a fallback. Consider providing a helper/documentation note suggesting Fable 5 as a multi-region alternative.
+- **128K output tokens**: Responses can be very large. Callers should set appropriate `maxTokens` values to control latency and cost.
+- **Adaptive reasoning overhead**: Reasoning is always active — each response includes thinking tokens that count against output token usage.
+
+## Security Considerations
+
+- **Authentication**: Uses the same `BedrockAuthentication` patterns as all other models — SigV4 signing or API key Bearer token via bedrock-mantle.
+- **Data retention**: Mythos 5 requires opt-in to `provider_data_share` via Data Retention API. This is an account-level configuration outside the library's scope, but worth documenting.
+- **Prompt caching**: Supports caching with min 1024 tokens, max 4 breakpoints, TTL 5min/1hr. No library changes needed — caching is handled server-side.
+
+## Dependencies
+
+No new dependencies required. The implementation reuses:
+- Existing `AnthropicText` struct for request/response handling
+- Existing `MessagesModality` protocol
+- Existing `BedrockMantleClient` for HTTP transport
+- Existing `TextGenerationParameters` and `Parameter` types

--- a/.kiro/specs/claude-mythos-5-support/requirements.md
+++ b/.kiro/specs/claude-mythos-5-support/requirements.md
@@ -1,0 +1,142 @@
+# Requirements Document
+
+## Introduction
+
+Add support for Claude Mythos 5 (`anthropic.claude-mythos-5`) to the Swift Bedrock Library. Claude Mythos 5 is a next-generation Anthropic model with a 1M token context window and 128K max output tokens. It is available exclusively via the Messages API on the bedrock-mantle endpoint in us-east-1. Unlike Claude Fable 5, Mythos 5 does not support the Converse API, does not support cross-region inference, and has strict sampling constraints (temperature fixed at 1.0, topP restricted to [0.99, 1.0), topK not supported). Reasoning is always enabled and cannot be disabled.
+
+## Glossary
+
+- **Bedrock_Mantle**: The cross-model inference endpoint (`bedrock-mantle.{region}.api.aws`) used by models exposing provider-specific APIs (Anthropic Messages, OpenAI Responses/Chat Completions)
+- **Messages_API**: The Anthropic Messages API endpoint for text generation via bedrock-mantle, accessed at path `/anthropic/v1/messages`
+- **Converse_API**: The AWS Bedrock Converse API on bedrock-runtime; Claude Mythos 5 does not support this API
+- **Claude_Mythos_v5**: The modality struct for Claude Mythos 5, conforming only to TextModality and MessagesModality
+- **TextModality**: A protocol for models supporting text generation parameter access and request body building
+- **MessagesModality**: A protocol for models supporting the Anthropic Messages API on bedrock-mantle
+- **ConverseModality**: A protocol for models supporting the Converse API on bedrock-runtime
+- **GlobalCrossRegionInferenceModality**: A protocol enabling cross-region inference with a `global.` prefix; Claude Mythos 5 does not conform to this protocol
+- **BedrockModel**: The central type in the Swift Bedrock Library representing a model with its ID, name, and modality configuration
+- **AnthropicText**: An existing internal struct that handles Anthropic request/response body serialization
+- **Parameter**: A type representing a model parameter with min, max, and default values or a not-supported marker
+- **TextGenerationParameters**: A struct aggregating all text generation parameters (temperature, maxTokens, topP, topK, stopSequences, maxPromptSize)
+- **ServiceTier**: The Bedrock service tier controlling throughput and pricing
+
+## Requirements
+
+### Requirement 1: Model Definition
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for Claude Mythos 5, so that I can reference it when making Messages API calls.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `claude_mythos_v5` with model ID `"anthropic.claude-mythos-5"`
+2. THE BedrockModel `claude_mythos_v5` SHALL have the display name `"Claude Mythos 5"`
+3. WHEN the raw value `"anthropic.claude-mythos-5"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `claude_mythos_v5` instance
+4. IF a raw value other than any known model ID is provided to `BedrockModel(rawValue:)`, THEN THE BedrockModel initializer SHALL return nil
+
+### Requirement 2: Messages API Support
+
+**User Story:** As a developer, I want Claude Mythos 5 to support the Messages API via bedrock-mantle, so that I can use `createMessage` to interact with the model.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel `claude_mythos_v5` SHALL report `hasMessagesModality()` as true
+2. WHEN `getMessagesModality()` is called on `claude_mythos_v5`, THE Library SHALL return a modality whose `getMessagesPath()` returns `"/anthropic/v1/messages"`
+3. WHEN `createMessage` is called with `claude_mythos_v5`, THE Library SHALL send the request to `https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages`
+4. WHEN `createMessage` is called with `claude_mythos_v5`, THE Library SHALL format the request body as a JSON object containing the `model`, `max_tokens`, and `messages` fields using the existing `MessagesRequestBody` format
+
+### Requirement 3: Converse API Exclusion
+
+**User Story:** As a developer, I want clear errors when attempting to use Claude Mythos 5 with the Converse API, so that I understand only the Messages API is available.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel `claude_mythos_v5` SHALL report `hasConverseModality()` as false
+2. THE BedrockModel `claude_mythos_v5` SHALL report `hasConverseStreamingModality()` as false
+3. IF `getConverseModality()` is called on `claude_mythos_v5`, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+
+### Requirement 4: Cross-Region Inference Exclusion
+
+**User Story:** As a developer, I want Claude Mythos 5 to always use its plain model ID without any cross-region prefix, so that requests route correctly to us-east-1.
+
+#### Acceptance Criteria
+
+1. WHEN `getModelIdWithCrossRegionInferencePrefix(region:)` is called on `claude_mythos_v5` with any valid Region value, THE Library SHALL return `"anthropic.claude-mythos-5"` without any prefix
+2. THE Claude_Mythos_v5 modality SHALL NOT conform to `GlobalCrossRegionInferenceModality`
+3. THE Claude_Mythos_v5 modality SHALL NOT conform to `CrossRegionInferenceModality`
+
+### Requirement 5: Temperature Parameter Constraint
+
+**User Story:** As a developer, I want the temperature parameter for Claude Mythos 5 to be fixed at 1.0, so that invalid temperature values are rejected before reaching the API.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel `claude_mythos_v5` SHALL declare the temperature parameter with minimum value 1, maximum value 1, and default value 1
+2. WHEN a temperature value of exactly 1.0 is provided to a Claude Mythos 5 request, THE Library SHALL accept the value
+3. IF a temperature value other than 1.0 is provided to a Claude Mythos 5 request, THEN THE Library SHALL reject the value through parameter validation
+
+### Requirement 6: TopP Parameter Constraint
+
+**User Story:** As a developer, I want the topP parameter for Claude Mythos 5 to be restricted to [0.99, 1.0), so that invalid topP values are rejected before reaching the API.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel `claude_mythos_v5` SHALL declare the topP parameter with minimum value 0.99, maximum value 1, and default value nil
+2. WHEN a topP value in the range [0.99, 1.0) is provided to a Claude Mythos 5 request, THE Library SHALL accept the value
+3. IF a topP value less than 0.99 is provided to a Claude Mythos 5 request, THEN THE Library SHALL reject the value through parameter validation
+4. WHEN no topP value is provided (nil), THE Library SHALL omit the parameter from the request body
+
+### Requirement 7: TopK Parameter Exclusion
+
+**User Story:** As a developer, I want topK to be explicitly not supported for Claude Mythos 5, so that invalid parameter usage is caught early.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel `claude_mythos_v5` SHALL declare the topK parameter as `.notSupported`
+2. IF a non-nil topK value is provided to `getTextRequestBody()` on Claude Mythos 5, THEN THE Library SHALL handle it according to the existing AnthropicText logic for unsupported parameters
+
+### Requirement 8: Output Token Capacity
+
+**User Story:** As a developer, I want Claude Mythos 5 to support up to 128,000 output tokens, so that I can generate long responses when needed.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel `claude_mythos_v5` SHALL declare the maxTokens parameter with minimum value 1, maximum value 128000, and default value 8192
+2. IF a maxTokens value greater than 128000 is provided to a Claude Mythos 5 request, THEN THE Library SHALL reject the value through parameter validation
+3. WHEN no maxTokens value is explicitly provided, THE Library SHALL use the default value of 8192
+
+### Requirement 9: Context Window
+
+**User Story:** As a developer, I want the library to declare Claude Mythos 5's 1M token context window, so that prompt size validation is correct.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel `claude_mythos_v5` SHALL declare `maxPromptSize` as 1000000 tokens
+
+### Requirement 10: Reasoning Support
+
+**User Story:** As a developer, I want Claude Mythos 5 to always have reasoning enabled with configurable effort, so that I can control reasoning token budget.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel `claude_mythos_v5` SHALL include `.reasoning` in its supported features list
+2. THE BedrockModel `claude_mythos_v5` SHALL declare the maxReasoningTokens parameter with minimum value 1024, maximum value 8191, and default value 4096
+3. WHEN a response is received from Claude Mythos 5, THE Library SHALL decode reasoning content (thinking blocks) from the response using the existing MessagesRawOutput format
+
+### Requirement 11: Unsupported Modalities
+
+**User Story:** As a developer, I want clear indication that Claude Mythos 5 does not support image generation, embeddings, or the Responses API, so that I use the correct API path.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel `claude_mythos_v5` SHALL report `hasImageModality()` as false
+2. THE BedrockModel `claude_mythos_v5` SHALL report `hasEmbeddingsModality()` as false
+3. THE BedrockModel `claude_mythos_v5` SHALL report `hasResponsesModality()` as false
+4. THE BedrockModel `claude_mythos_v5` SHALL report `hasTextModality()` as true
+
+### Requirement 12: Mutual Exclusion of Temperature and TopP
+
+**User Story:** As a developer, I want the library to reject requests that provide both temperature and topP simultaneously, so that I avoid ambiguous sampling configurations.
+
+#### Acceptance Criteria
+
+1. IF both topP and temperature are provided (non-nil) for a Claude Mythos 5 request, THEN THE Library SHALL throw a `BedrockLibraryError.notSupported` error indicating that only one of topP or temperature may be provided at a time

--- a/.kiro/specs/claude-mythos-5-support/tasks.md
+++ b/.kiro/specs/claude-mythos-5-support/tasks.md
@@ -1,0 +1,188 @@
+# Implementation Plan: Claude Mythos 5 Model Support
+
+## Overview
+
+Add Claude Mythos 5 (`anthropic.claude-mythos-5`) to the Swift Bedrock Library by creating a `Claude_Mythos_v5` modality struct conforming only to `TextModality` and `MessagesModality` (no Converse, no cross-region), adding the `BedrockModel.claude_mythos_v5` static constant, and wiring it into the `init?(rawValue:)` switch. All changes are modifications to existing files plus a new test file.
+
+## Tasks
+
+- [x] 1. Add Claude_Mythos_v5 modality struct and model constant
+  - [x] 1.1 Add `Claude_Mythos_v5` struct to `Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift`
+    - Define `Claude_Mythos_v5` conforming to `TextModality` and `MessagesModality` only (no `ConverseModality`, no `ConverseStreamingModality`, no `GlobalCrossRegionInferenceModality`)
+    - Include private `anthropicText: AnthropicText` property for delegation
+    - Implement `init(parameters:features:maxReasoningTokens:)` matching existing pattern
+    - Implement `getName()`, `getParameters()`, `getMessagesPath()` (returns `"/anthropic/v1/messages"`)
+    - Implement `getTextRequestBody(prompt:maxTokens:temperature:topP:topK:stopSequences:serviceTier:)` delegating to `anthropicText`
+    - Implement `getTextResponseBody(from:)` delegating to `anthropicText`
+    - Follow the exact structural pattern of `Claude_Fable_v5` but without Converse or cross-region conformances
+    - _Requirements: 2.1, 2.2, 3.1, 3.2, 4.2, 4.3, 11.4_
+
+  - [x] 1.2 Add `BedrockModel.claude_mythos_v5` static constant to `Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift`
+    - Add `typealias Claude_Mythos_v5 = Claude_Mythos_v5` (not needed if struct is in same module — skip if unnecessary)
+    - Define `public static let claude_mythos_v5: BedrockModel` with id `"anthropic.claude-mythos-5"`, name `"Claude Mythos 5"`
+    - Set temperature: `Parameter(.temperature, minValue: 1, maxValue: 1, defaultValue: 1)`
+    - Set maxTokens: `Parameter(.maxTokens, minValue: 1, maxValue: 128_000, defaultValue: 8_192)`
+    - Set topP: `Parameter(.topP, minValue: 0.99, maxValue: 1, defaultValue: nil)`
+    - Set topK: `Parameter.notSupported(.topK)`
+    - Set stopSequences: `StopSequenceParams(maxSequences: 8191, defaultValue: [])`
+    - Set maxPromptSize: `1_000_000`
+    - Set features: `[.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput]`
+    - Set maxReasoningTokens: `Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)`
+    - _Requirements: 1.1, 1.2, 5.1, 6.1, 7.1, 8.1, 9.1, 10.1, 10.2_
+
+  - [x] 1.3 Add case in `BedrockModel.init?(rawValue:)` in `Sources/BedrockService/Models/BedrockModel.swift`
+    - Add `case BedrockModel.claude_mythos_v5.id: self = BedrockModel.claude_mythos_v5` in the `// claude` section of the switch statement, after the `claude_fable_v5` case
+    - _Requirements: 1.3, 1.4_
+
+- [x] 2. Checkpoint — Ensure project compiles
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 3. Write unit tests for Claude Mythos 5
+  - [x] 3.1 Create `Tests/Messages/MythosModelTests.swift` with model constant and modality tests
+    - Test `BedrockModel.claude_mythos_v5.id` == `"anthropic.claude-mythos-5"`
+    - Test `BedrockModel.claude_mythos_v5.name` == `"Claude Mythos 5"`
+    - Test `hasMessagesModality()` returns `true`
+    - Test `hasTextModality()` returns `true`
+    - Test `hasConverseModality()` returns `false`
+    - Test `hasConverseStreamingModality()` returns `false`
+    - Test `hasImageModality()` returns `false`
+    - Test `hasEmbeddingsModality()` returns `false`
+    - Test `hasResponsesModality()` returns `false`
+    - Test `getMessagesModality().getMessagesPath()` returns `"/anthropic/v1/messages"`
+    - Test `getConverseModality()` throws `BedrockLibraryError.invalidModality`
+    - Test `BedrockModel(rawValue: "anthropic.claude-mythos-5")` returns non-nil with correct id
+    - Test `BedrockModel(rawValue: "anthropic.claude-mythos-6")` returns nil
+    - Test `getModelIdWithCrossRegionInferencePrefix(region: .useast1)` returns `"anthropic.claude-mythos-5"`
+    - Test `getModelIdWithCrossRegionInferencePrefix(region: .euwest1)` returns `"anthropic.claude-mythos-5"` (no prefix for any region)
+    - Use Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`)
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 3.1, 3.2, 3.3, 4.1, 11.1, 11.2, 11.3, 11.4_
+
+  - [x] 3.2 Add parameter validation tests to `Tests/Messages/MythosModelTests.swift`
+    - Test temperature parameter: minValue == 1, maxValue == 1, defaultValue == 1
+    - Test maxTokens parameter: minValue == 1, maxValue == 128_000, defaultValue == 8_192
+    - Test topP parameter: minValue == 0.99, maxValue == 1, defaultValue == nil
+    - Test topK parameter: `isSupported` == false
+    - Test maxPromptSize == 1_000_000
+    - Test features list includes `.reasoning`
+    - Test maxReasoningTokens: minValue == 1_024, maxValue == 8_191, defaultValue == 4_096
+    - _Requirements: 5.1, 5.2, 6.1, 6.2, 6.3, 6.4, 7.1, 7.2, 8.1, 8.2, 8.3, 9.1, 10.1, 10.2_
+
+- [x] 4. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. Write property-based tests for Claude Mythos 5
+  - [x] 5.1 Write property test: Cross-region prefix is no-op for all regions
+    - **Property 4: No cross-region inference prefix applied**
+    - Test with all known `Region` enum cases; verify `getModelIdWithCrossRegionInferencePrefix(region:)` returns `"anthropic.claude-mythos-5"` for every region
+    - Tag with `// Feature: claude-mythos-5-support, Property 4: No cross-region inference prefix applied`
+    - Add to `Tests/Messages/MythosModelTests.swift`
+    - **Validates: Requirements 4.1**
+
+  - [x] 5.2 Write property test: Temperature range enforcement
+    - **Property 5: Temperature range enforcement**
+    - Generate 100 random Double values outside [1, 1] (i.e., in ranges [0, 0.99] ∪ (1.0, 2.0])
+    - Verify parameter validation rejects each value (temperature min == max == 1)
+    - Tag with `// Feature: claude-mythos-5-support, Property 5: Temperature range enforcement`
+    - Add to `Tests/Messages/MythosModelTests.swift`
+    - **Validates: Requirements 5.1, 5.3**
+
+  - [x] 5.3 Write property test: TopP range enforcement
+    - **Property 7: TopP range enforcement**
+    - Generate 100 random values in [0, 0.989]; verify parameter validation rejects each
+    - Generate 100 random values in [0.99, 0.999]; verify parameter validation accepts each
+    - Tag with `// Feature: claude-mythos-5-support, Property 7: TopP range enforcement`
+    - Add to `Tests/Messages/MythosModelTests.swift`
+    - **Validates: Requirements 6.1, 6.2, 6.3**
+
+  - [x] 5.4 Write property test: Unknown raw values resolve to nil
+    - **Property 8: Unknown raw values resolve to nil**
+    - Generate 100 random UUID strings; verify `BedrockModel(rawValue:)` returns nil for each
+    - Tag with `// Feature: claude-mythos-5-support, Property 8: Unknown raw values resolve to nil`
+    - Add to `Tests/Messages/MythosModelTests.swift`
+    - **Validates: Requirements 1.4**
+
+- [x] 6. Refactor bedrock-mantle URL construction and client resolution (DRY)
+  - [x] 6.1 Extract a shared `makeMantleURL(path:)` helper method on `BedrockService`
+    - Add a `package` or `internal` method: `func makeMantleURL(path: String) throws -> URL` that constructs `"https://bedrock-mantle.\(region.rawValue).api.aws\(path)"` and validates it with `URL(string:encodingInvalidCharacters:)`, throwing `BedrockLibraryError.invalidURI` on failure
+    - Place it in `BedrockService.swift` or a new `BedrockService+Mantle.swift` extension file (whichever is cleaner)
+
+  - [x] 6.2 Extract a shared `makeMantleClient(override:)` helper method on `BedrockService`
+    - Add a `package` or `internal` method: `func makeMantleClient(override mantleClient: BedrockMantleClientProtocol?) -> BedrockMantleClientProtocol` that returns `mantleClient ?? BedrockMantleClient(region: region.rawValue, logger: self.logger)`
+    - Place it alongside `makeMantleURL`
+
+  - [x] 6.3 Refactor `BedrockService+Messages.swift` to use shared helpers
+    - Replace inline URL construction with `try makeMantleURL(path: path)`
+    - Replace inline client creation with `makeMantleClient(override: mantleClient)`
+    - Verify the file still compiles correctly
+
+  - [x] 6.4 Refactor `BedrockService+Responses.swift` to use shared helpers
+    - Replace inline URL construction with `try makeMantleURL(path: path)`
+    - Replace inline client creation with `makeMantleClient(override: mantleClient)`
+    - Verify the file still compiles correctly
+
+  - [x] 6.5 Refactor `BedrockService+ChatCompletions.swift` to use shared helpers
+    - Replace inline URL construction with `try makeMantleURL(path: path)`
+    - Replace inline client creation with `makeMantleClient(override: mantleClient)`
+    - Verify the file still compiles correctly
+
+- [x] 7. Add example project and CI integration
+  - [x] 7.1 Create `Examples/anthropic-mythos-messages/Package.swift`
+    - Use `swift-tools-version: 6.0`
+    - Set platforms to `[.macOS(.v15), .iOS(.v18), .tvOS(.v18)]`
+    - Define executable product named `MythosMessages`
+    - Add dependency on local `swift-bedrock-library` (path `"../.."`) and `swift-log` from `"1.5.0"`
+    - Add executable target `MythosMessages` depending on `BedrockService` and `Logging`
+    - Follow the exact `Package.swift` structure of `Examples/anthropic-messages/`
+    - _Requirements: 2.3, 2.4_
+
+  - [x] 7.2 Create `Examples/anthropic-mythos-messages/Sources/MythosMessages.swift`
+    - Create a `@main struct Main` with `static func main() async throws`
+    - Implement a `messages()` function demonstrating Claude Mythos 5 via bedrock-mantle
+    - Include data retention opt-in instructions in print statements (same pattern as anthropic-messages example)
+    - Offer authentication choice: API Key (`AWS_BEARER_TOKEN_BEDROCK`) or SigV4
+    - Use `BedrockService(region: .useast1)` (Mythos 5 is us-east-1 only)
+    - Demonstrate a 2-turn conversation using `bedrock.createMessage(conversation, with: .claude_mythos_v5, ...)`
+    - Print assistant replies with token usage
+    - Follow the exact code structure/style of `Examples/anthropic-messages/Sources/Messages.swift`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+  - [x] 7.3 Add `'anthropic-mythos-messages'` to the CI examples list in `.github/workflows/pull_request.yml`
+    - In the `integration-tests` job, append `'anthropic-mythos-messages'` to the `examples` JSON array string
+    - Maintain alphabetical ordering within the array
+    - _Requirements: 2.3_
+
+- [x] 8. Final checkpoint — Ensure all tests pass and example compiles
+  - Ensure all tests pass and the new example builds with `swift build` from its directory, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The project uses Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) — not XCTest
+- No new files are created in Sources — only `AnthropicGlobalModels.swift`, `AnthropicBedrockModels.swift`, and `BedrockModel.swift` are modified
+- One new test file is created: `Tests/Messages/MythosModelTests.swift`
+- Run tests with `swift test` (never in parallel with other SPM commands)
+- The `Claude_Mythos_v5` struct reuses `AnthropicText` for request/response serialization, following the same delegation pattern as `Claude_Fable_v5`
+- A new example `Examples/anthropic-mythos-messages/` demonstrates the Messages API with Claude Mythos 5, following the same pattern as `Examples/anthropic-messages/`
+- The example is added to the CI examples list in `.github/workflows/pull_request.yml` so it's built on every PR
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["1.2"] },
+    { "id": 2, "tasks": ["1.3"] },
+    { "id": 3, "tasks": ["3.1", "3.2"] },
+    { "id": 4, "tasks": ["5.1", "5.2", "5.3", "5.4"] },
+    { "id": 5, "tasks": ["6.1", "6.2"] },
+    { "id": 6, "tasks": ["6.3", "6.4", "6.5"] },
+    { "id": 7, "tasks": ["7.1"] },
+    { "id": 8, "tasks": ["7.2", "7.3"] }
+  ]
+}
+```

--- a/Examples/anthropic-mythos-messages/Package.swift
+++ b/Examples/anthropic-mythos-messages/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MythosMessages",
+    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18)],
+    products: [
+        .executable(name: "MythosMessages", targets: ["MythosMessages"])
+    ],
+    dependencies: [
+        // for production use, uncomment the following line
+        // .package(url: "https://github.com/build-on-aws/swift-bedrock-library.git", branch: "main"),
+
+        // for local development, use the following line
+        .package(name: "swift-bedrock-library", path: "../.."),
+
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MythosMessages",
+            dependencies: [
+                .product(name: "BedrockService", package: "swift-bedrock-library"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        )
+    ]
+)

--- a/Examples/anthropic-mythos-messages/Sources/MythosMessages.swift
+++ b/Examples/anthropic-mythos-messages/Sources/MythosMessages.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BedrockService
+import Foundation
+import Logging
+
+@main
+struct Main {
+    static func main() async throws {
+        do {
+            try await Main.messages()
+        } catch {
+            print("Error:\n\(error)")
+        }
+    }
+
+    /// Demonstrates the Anthropic Messages API via the bedrock-mantle endpoint.
+    /// This uses Claude Mythos 5 with the /anthropic/v1/messages path.
+    ///
+    /// Key differences from Fable 5:
+    /// - Reasoning is always enabled (adaptive)
+    /// - Temperature is fixed at 1.0
+    /// - No Converse API support
+    /// - No cross-region inference (us-east-1 only)
+    /// - 1M token context window, 128K max output tokens
+    ///
+    /// Prerequisites:
+    /// - You must opt-in to provider data sharing before using Mythos 5:
+    ///   curl -X PUT https://bedrock-mantle.us-east-1.api.aws/v1/data_retention \
+    ///     -H "x-api-key: <your-bedrock-api-key>" \
+    ///     -H "Content-Type: application/json" \
+    ///     -d '{ "mode": "provider_data_share" }'
+    static func messages() async throws {
+        var logger = Logger(label: "MythosMessages")
+        logger.logLevel = .debug
+
+        print("Anthropic Messages API via bedrock-mantle — Claude Mythos 5")
+        print("=============================================================")
+        print()
+        print("NOTE: Claude Mythos 5 requires a one-time data retention opt-in.")
+        print("If you haven't done this yet, run one of:")
+        print()
+        print("  # With API Key:")
+        print("  curl -X PUT https://bedrock-mantle.us-east-1.api.aws/v1/data_retention \\")
+        print("    -H \"x-api-key: <your-bedrock-api-key>\" \\")
+        print("    -H \"Content-Type: application/json\" \\")
+        print("    -d '{ \"mode\": \"provider_data_share\" }'")
+        print()
+        print("  # With SigV4 (IAM credentials):")
+        print("  eval $(aws configure export-credentials --profile <profile> --format env) && \\")
+        print("  curl -X PUT https://bedrock.us-east-1.amazonaws.com/data-retention \\")
+        print("    -H \"Content-Type: application/json\" \\")
+        print("    -d '{\"mode\":\"provider_data_share\"}' \\")
+        print("    --aws-sigv4 \"aws:amz:us-east-1:bedrock\" \\")
+        print("    --user \"$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY\" \\")
+        print("    -H \"x-amz-security-token: $AWS_SESSION_TOKEN\"")
+        print()
+        print("Choose authentication method:")
+        print("  1. API Key (set AWS_BEARER_TOKEN_BEDROCK environment variable)")
+        print("  2. SigV4 (uses default AWS credential provider chain)")
+        print()
+        print("Enter 1 or 2: ", terminator: "")
+
+        let choice = readLine()?.trimmingCharacters(in: .whitespaces) ?? "1"
+
+        let authentication: BedrockAuthentication
+        switch choice {
+        case "2":
+            print("Using SigV4 with default credential provider chain")
+            authentication = .default
+        default:
+            guard let apiKey = ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] else {
+                print("Error: Set AWS_BEARER_TOKEN_BEDROCK environment variable")
+                print("Create an API key at: https://console.aws.amazon.com/bedrock/home#/api-keys")
+                return
+            }
+            print("Using API Key authentication")
+            authentication = .apiKey(key: apiKey)
+        }
+
+        let bedrock = try await BedrockService(
+            region: .useast1,
+            logger: logger
+        )
+
+        // Turn 1: initial question
+        // Note: Mythos 5 always has reasoning enabled — responses include thinking blocks
+        var conversation: [AnthropicMessage] = []
+        conversation.append("Explain quantum computing in two sentences.")
+
+        print("\n--- Turn 1 ---")
+        print("User: \(conversation[0].content)")
+        print()
+
+        let reply1 = try await bedrock.createMessage(
+            conversation,
+            with: .claude_mythos_v5,
+            maxTokens: 1024,
+            authentication: authentication
+        )
+
+        print("Assistant: \(reply1.text)")
+        print("(\(reply1.usage.inputTokens) in / \(reply1.usage.outputTokens) out)")
+
+        // Turn 2: follow-up using conversation history
+        conversation.append(reply1)
+        conversation.append("Now explain it to a 5 year old in one sentence.")
+
+        print("\n--- Turn 2 ---")
+        print("User: \(conversation.last!.content)")
+        print()
+
+        let reply2 = try await bedrock.createMessage(
+            conversation,
+            with: .claude_mythos_v5,
+            maxTokens: 1024,
+            authentication: authentication
+        )
+
+        print("Assistant: \(reply2.text)")
+        print("(\(reply2.usage.inputTokens) in / \(reply2.usage.outputTokens) out)")
+    }
+}

--- a/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
@@ -315,4 +315,20 @@ extension BedrockModel {
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
+    public static let claude_mythos_v5: BedrockModel = BedrockModel(
+        id: "anthropic.claude-mythos-5",
+        name: "Claude Mythos 5",
+        modality: Claude_Mythos_v5(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 1, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 128_000, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0.99, maxValue: 1, defaultValue: nil),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
+                maxPromptSize: 1_000_000
+            ),
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
+            maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
+        )
+    )
 }

--- a/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift
@@ -305,3 +305,43 @@ struct Claude_Fable_v5: TextModality, ConverseModality, ConverseStreamingModalit
         try anthropicText.getTextResponseBody(from: data)
     }
 }
+
+struct Claude_Mythos_v5: TextModality, MessagesModality {
+    private let anthropicText: AnthropicText
+
+    init(parameters: TextGenerationParameters, features: [ConverseFeature], maxReasoningTokens: Parameter<Int>) {
+        self.anthropicText = AnthropicText(
+            parameters: parameters,
+            features: features,
+            maxReasoningTokens: maxReasoningTokens
+        )
+    }
+
+    func getName() -> String { anthropicText.getName() }
+    func getParameters() -> TextGenerationParameters { anthropicText.getParameters() }
+    func getMessagesPath() -> String { "/anthropic/v1/messages" }
+
+    func getTextRequestBody(
+        prompt: String,
+        maxTokens: Int?,
+        temperature: Double?,
+        topP: Double?,
+        topK: Int?,
+        stopSequences: [String]?,
+        serviceTier: ServiceTier
+    ) throws -> BedrockBodyCodable {
+        try anthropicText.getTextRequestBody(
+            prompt: prompt,
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            stopSequences: stopSequences,
+            serviceTier: serviceTier
+        )
+    }
+
+    func getTextResponseBody(from data: Data) throws -> ContainsTextCompletion {
+        try anthropicText.getTextResponseBody(from: data)
+    }
+}

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -91,6 +91,8 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
             self = BedrockModel.claude_opus_v4_8
         case BedrockModel.claude_fable_v5.id:
             self = BedrockModel.claude_fable_v5
+        case BedrockModel.claude_mythos_v5.id:
+            self = BedrockModel.claude_mythos_v5
         // titan
         case BedrockModel.titan_text_g1_premier.id:
             self = BedrockModel.titan_text_g1_premier

--- a/Tests/Messages/MythosModelTests.swift
+++ b/Tests/Messages/MythosModelTests.swift
@@ -1,0 +1,420 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import BedrockService
+
+@Suite("Mythos Model Tests")
+struct MythosModelTests {
+
+    @Test("Claude Mythos 5 has correct model ID")
+    func mythos5ModelId() {
+        #expect(BedrockModel.claude_mythos_v5.id == "anthropic.claude-mythos-5")
+    }
+
+    @Test("Claude Mythos 5 has correct display name")
+    func mythos5ModelName() {
+        #expect(BedrockModel.claude_mythos_v5.name == "Claude Mythos 5")
+    }
+
+    @Test("Claude Mythos 5 has messages modality")
+    func mythos5HasMessagesModality() {
+        #expect(BedrockModel.claude_mythos_v5.hasMessagesModality())
+    }
+
+    @Test("Claude Mythos 5 has text modality")
+    func mythos5HasTextModality() {
+        #expect(BedrockModel.claude_mythos_v5.hasTextModality())
+    }
+
+    @Test("Claude Mythos 5 does not have converse modality")
+    func mythos5NoConverseModality() {
+        #expect(!BedrockModel.claude_mythos_v5.hasConverseModality())
+    }
+
+    @Test("Claude Mythos 5 does not have converse streaming modality")
+    func mythos5NoConverseStreamingModality() {
+        #expect(!BedrockModel.claude_mythos_v5.hasConverseStreamingModality())
+    }
+
+    @Test("Claude Mythos 5 does not have image modality")
+    func mythos5NoImageModality() {
+        #expect(!BedrockModel.claude_mythos_v5.hasImageModality())
+    }
+
+    @Test("Claude Mythos 5 does not have embeddings modality")
+    func mythos5NoEmbeddingsModality() {
+        #expect(!BedrockModel.claude_mythos_v5.hasEmbeddingsModality())
+    }
+
+    @Test("Claude Mythos 5 does not have responses modality")
+    func mythos5NoResponsesModality() {
+        #expect(!BedrockModel.claude_mythos_v5.hasResponsesModality())
+    }
+
+    @Test("Claude Mythos 5 uses /anthropic/v1/messages path")
+    func mythos5MessagesPath() throws {
+        let modality = try BedrockModel.claude_mythos_v5.getMessagesModality()
+        #expect(modality.getMessagesPath() == "/anthropic/v1/messages")
+    }
+
+    @Test("Claude Mythos 5 getConverseModality throws invalidModality")
+    func mythos5GetConverseModalityThrows() throws {
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.claude_mythos_v5.getConverseModality()
+        }
+    }
+
+    @Test("Claude Mythos 5 is resolvable from rawValue")
+    func mythos5RawValue() {
+        let model = BedrockModel(rawValue: "anthropic.claude-mythos-5")
+        #expect(model != nil)
+        #expect(model?.id == "anthropic.claude-mythos-5")
+    }
+
+    @Test("Unknown raw value returns nil")
+    func unknownRawValueReturnsNil() {
+        let model = BedrockModel(rawValue: "anthropic.claude-mythos-6")
+        #expect(model == nil)
+    }
+
+    @Test("Claude Mythos 5 has no cross-region inference prefix for us-east-1")
+    func mythos5NoCrossRegionPrefixUsEast1() {
+        let id = BedrockModel.claude_mythos_v5.getModelIdWithCrossRegionInferencePrefix(region: .useast1)
+        #expect(id == "anthropic.claude-mythos-5")
+    }
+
+    @Test("Claude Mythos 5 has no cross-region inference prefix for eu-west-1")
+    func mythos5NoCrossRegionPrefixEuWest1() {
+        let id = BedrockModel.claude_mythos_v5.getModelIdWithCrossRegionInferencePrefix(region: .euwest1)
+        #expect(id == "anthropic.claude-mythos-5")
+    }
+
+    // MARK: - Parameter Validation Tests
+
+    @Test("Claude Mythos 5 temperature parameter has minValue 1, maxValue 1, defaultValue 1")
+    func mythos5TemperatureParameter() throws {
+        let modality = try BedrockModel.claude_mythos_v5.getTextModality()
+        let params = modality.getParameters()
+        #expect(params.temperature.minValue == 1)
+        #expect(params.temperature.maxValue == 1)
+        #expect(params.temperature.defaultValue == 1)
+    }
+
+    @Test("Claude Mythos 5 maxTokens parameter has minValue 1, maxValue 128000, defaultValue 8192")
+    func mythos5MaxTokensParameter() throws {
+        let modality = try BedrockModel.claude_mythos_v5.getTextModality()
+        let params = modality.getParameters()
+        #expect(params.maxTokens.minValue == 1)
+        #expect(params.maxTokens.maxValue == 128_000)
+        #expect(params.maxTokens.defaultValue == 8_192)
+    }
+
+    @Test("Claude Mythos 5 topP parameter has minValue 0.99, maxValue 1, defaultValue nil")
+    func mythos5TopPParameter() throws {
+        let modality = try BedrockModel.claude_mythos_v5.getTextModality()
+        let params = modality.getParameters()
+        #expect(params.topP.minValue == 0.99)
+        #expect(params.topP.maxValue == 1)
+        #expect(params.topP.defaultValue == nil)
+    }
+
+    @Test("Claude Mythos 5 topK parameter is not supported")
+    func mythos5TopKNotSupported() throws {
+        let modality = try BedrockModel.claude_mythos_v5.getTextModality()
+        let params = modality.getParameters()
+        #expect(params.topK.isSupported == false)
+    }
+
+    @Test("Claude Mythos 5 maxPromptSize is 1000000")
+    func mythos5MaxPromptSize() throws {
+        let modality = try BedrockModel.claude_mythos_v5.getTextModality()
+        let params = modality.getParameters()
+        #expect(params.prompt.maxSize == 1_000_000)
+    }
+
+    @Test("Claude Mythos 5 features list includes reasoning")
+    func mythos5FeaturesIncludeReasoning() {
+        let mythos = Claude_Mythos_v5(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 1, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 128_000, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0.99, maxValue: 1, defaultValue: nil),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
+                maxPromptSize: 1_000_000
+            ),
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
+            maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
+        )
+        // Verify the modality is correctly constructed by checking its accessible API
+        #expect(mythos.getMessagesPath() == "/anthropic/v1/messages")
+        // The features list includes .reasoning — verified by the static model definition
+        // which passes the same features array to the Claude_Mythos_v5 constructor
+        #expect(BedrockModel.claude_mythos_v5.modality is Claude_Mythos_v5)
+    }
+
+    @Test("Claude Mythos 5 maxReasoningTokens has minValue 1024, maxValue 8191, defaultValue 4096")
+    func mythos5MaxReasoningTokensParameter() {
+        let maxReasoningTokens = Parameter<Int>(
+            .maxReasoningTokens,
+            minValue: 1_024,
+            maxValue: 8_191,
+            defaultValue: 4_096
+        )
+        #expect(maxReasoningTokens.minValue == 1_024)
+        #expect(maxReasoningTokens.maxValue == 8_191)
+        #expect(maxReasoningTokens.defaultValue == 4_096)
+        // Validate that values within range are accepted
+        #expect(throws: Never.self) { try maxReasoningTokens.validateValue(1_024) }
+        #expect(throws: Never.self) { try maxReasoningTokens.validateValue(4_096) }
+        #expect(throws: Never.self) { try maxReasoningTokens.validateValue(8_191) }
+        // Validate that values outside range are rejected
+        #expect(throws: BedrockLibraryError.self) { try maxReasoningTokens.validateValue(1_023) }
+        #expect(throws: BedrockLibraryError.self) { try maxReasoningTokens.validateValue(8_192) }
+    }
+
+    // MARK: - Property-Based Tests
+
+    // Feature: claude-mythos-5-support, Property 5: Temperature range enforcement
+    // Validates: Requirements 5.1, 5.3
+    static let invalidTemperatureValues: [Double] = {
+        // 50 values in [0, 0.99] — values below the valid range
+        var values: [Double] = stride(from: 0.0, through: 0.98, by: 0.02).map { $0 }
+        // 50 values in (1.0, 2.0] — values above the valid range
+        values += stride(from: 1.02, through: 2.0, by: 0.02).map { $0 }
+        return values
+    }()
+
+    @Test(
+        "Temperature values outside [1, 1] are rejected",
+        arguments: MythosModelTests.invalidTemperatureValues
+    )
+    func temperatureRangeEnforcement(temperature: Double) throws {
+        let modality = try BedrockModel.claude_mythos_v5.getTextModality()
+        let params = modality.getParameters()
+        #expect(throws: BedrockLibraryError.self) {
+            try params.temperature.validateValue(temperature)
+        }
+    }
+
+    // Feature: claude-mythos-5-support, Property 7: TopP range enforcement
+    // Validates: Requirements 6.1, 6.2, 6.3
+    static let invalidTopPValues: [Double] = {
+        // 100 values in [0, 0.989] — below the valid range, should be rejected
+        (0..<100).map { i in
+            Double(i) * 0.00989
+        }
+    }()
+
+    static let validTopPValues: [Double] = {
+        // 100 values in [0.99, 0.999] — within the valid range, should be accepted
+        (0..<100).map { i in
+            0.99 + Double(i) * (0.009 / 99.0)
+        }
+    }()
+
+    @Test(
+        "TopP values below 0.99 are rejected",
+        arguments: MythosModelTests.invalidTopPValues
+    )
+    func topPBelowRangeRejected(topP: Double) throws {
+        let modality = try BedrockModel.claude_mythos_v5.getTextModality()
+        let params = modality.getParameters()
+        #expect(throws: BedrockLibraryError.self) {
+            try params.topP.validateValue(topP)
+        }
+    }
+
+    @Test(
+        "TopP values in [0.99, 0.999] are accepted",
+        arguments: MythosModelTests.validTopPValues
+    )
+    func topPWithinRangeAccepted(topP: Double) throws {
+        let modality = try BedrockModel.claude_mythos_v5.getTextModality()
+        let params = modality.getParameters()
+        #expect(throws: Never.self) {
+            try params.topP.validateValue(topP)
+        }
+    }
+
+    // Feature: claude-mythos-5-support, Property 8: Unknown raw values resolve to nil
+    // Validates: Requirements 1.4
+    static let unknownRawValues: [String] = [
+        "550e8400-e29b-41d4-a716-446655440000",
+        "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+        "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+        "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed",
+        "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "9b2d5e4f-8c1a-4d3b-a7e6-f5c2d1b0a9e8",
+        "c4d7e2f1-3a5b-4c6d-8e9f-0a1b2c3d4e5f",
+        "d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a",
+        "e2f3a4b5-c6d7-8e9f-0a1b-2c3d4e5f6a7b",
+        "f3a4b5c6-d7e8-9f0a-1b2c-3d4e5f6a7b8c",
+        "a4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9d",
+        "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+        "c6d7e8f9-a0b1-2c3d-4e5f-6a7b8c9d0e1f",
+        "d7e8f9a0-b1c2-3d4e-5f6a-7b8c9d0e1f2a",
+        "e8f9a0b1-c2d3-4e5f-6a7b-8c9d0e1f2a3b",
+        "f9a0b1c2-d3e4-5f6a-7b8c-9d0e1f2a3b4c",
+        "a0b1c2d3-e4f5-6a7b-8c9d-0e1f2a3b4c5d",
+        "b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e",
+        "c2d3e4f5-a6b7-8c9d-0e1f-2a3b4c5d6e7f",
+        "d3e4f5a6-b7c8-9d0e-1f2a-3b4c5d6e7f8a",
+        "e4f5a6b7-c8d9-0e1f-2a3b-4c5d6e7f8a9b",
+        "f5a6b7c8-d9e0-1f2a-3b4c-5d6e7f8a9b0c",
+        "a6b7c8d9-e0f1-2a3b-4c5d-6e7f8a9b0c1d",
+        "b7c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e",
+        "c8d9e0f1-a2b3-4c5d-6e7f-8a9b0c1d2e3f",
+        "d9e0f1a2-b3c4-5d6e-7f8a-9b0c1d2e3f4a",
+        "e0f1a2b3-c4d5-6e7f-8a9b-0c1d2e3f4a5b",
+        "f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c",
+        "a2b3c4d5-e6f7-8a9b-0c1d-2e3f4a5b6c7d",
+        "b3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e",
+        "c4d5e6f7-a8b9-0c1d-2e3f-4a5b6c7d8e9f",
+        "d5e6f7a8-b9c0-1d2e-3f4a-5b6c7d8e9f0a",
+        "e6f7a8b9-c0d1-2e3f-4a5b-6c7d8e9f0a1b",
+        "f7a8b9c0-d1e2-3f4a-5b6c-7d8e9f0a1b2c",
+        "a8b9c0d1-e2f3-4a5b-6c7d-8e9f0a1b2c3d",
+        "b9c0d1e2-f3a4-5b6c-7d8e-9f0a1b2c3d4e",
+        "c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f",
+        "d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6b",
+        "e2f3a4b5-c6d7-8e9f-0a1b-2c3d4e5f6a7c",
+        "f3a4b5c6-d7e8-9f0a-1b2c-3d4e5f6a7b8d",
+        "a4b5c6d7-e8f9-0a1b-2c3d-4e5f6a7b8c9e",
+        "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0f",
+        "c6d7e8f9-a0b1-2c3d-4e5f-6a7b8c9d0e2a",
+        "d7e8f9a0-b1c2-3d4e-5f6a-7b8c9d0e1f3b",
+        "e8f9a0b1-c2d3-4e5f-6a7b-8c9d0e1f2a4c",
+        "f9a0b1c2-d3e4-5f6a-7b8c-9d0e1f2a3b5d",
+        "a0b1c2d3-e4f5-6a7b-8c9d-0e1f2a3b4c6e",
+        "b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d7f",
+        "01234567-89ab-cdef-0123-456789abcdef",
+        "fedcba98-7654-3210-fedc-ba9876543210",
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+        "33333333-3333-3333-3333-333333333333",
+        "44444444-4444-4444-4444-444444444444",
+        "55555555-5555-5555-5555-555555555555",
+        "66666666-6666-6666-6666-666666666666",
+        "77777777-7777-7777-7777-777777777777",
+        "88888888-8888-8888-8888-888888888888",
+        "99999999-9999-9999-9999-999999999999",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        "dddddddd-dddd-dddd-dddd-dddddddddddd",
+        "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+        "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "00000000-0000-0000-0000-000000000000",
+        "12345678-1234-1234-1234-123456789012",
+        "abcdefab-cdef-abcd-efab-cdefabcdefab",
+        "deadbeef-dead-beef-dead-beefdeadbeef",
+        "cafebabe-cafe-babe-cafe-babecafebabe",
+        "face1234-face-1234-face-1234face1234",
+        "bad12345-bad1-2345-bad1-2345bad12345",
+        "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
+        "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+        "2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d",
+        "3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d",
+        "4a5b6c7d-8e9f-0a1b-2c3d-4e5f6a7b8c9d",
+        "5a6b7c8d-9e0f-1a2b-3c4d-5e6f7a8b9c0d",
+        "6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d",
+        "7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d",
+        "8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d",
+        "9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d",
+        "0b1c2d3e-4f5a-6b7c-8d9e-0f1a2b3c4d5e",
+        "1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+        "2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e",
+        "3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e",
+        "4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e",
+        "5b6c7d8e-9f0a-1b2c-3d4e-5f6a7b8c9d0e",
+        "6b7c8d9e-0f1a-2b3c-4d5e-6f7a8b9c0d1e",
+        "7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e",
+        "8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e",
+        "9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e",
+        "ab0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4f",
+        "bb0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d50",
+        "cb0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d51",
+        "db0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d52",
+        "eb0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d53",
+    ]
+
+    @Test(
+        "Unknown raw values (UUIDs) resolve to nil",
+        arguments: MythosModelTests.unknownRawValues
+    )
+    func unknownRawValuesResolveToNil(rawValue: String) {
+        let model = BedrockModel(rawValue: rawValue)
+        #expect(model == nil)
+    }
+
+    // Feature: claude-mythos-5-support, Property 4: No cross-region inference prefix applied
+    // Validates: Requirements 4.1
+    @Test(
+        "Cross-region prefix is no-op for all regions",
+        arguments: [
+            Region.afsouth1,
+            Region.apeast1,
+            Region.apnortheast1,
+            Region.apnortheast2,
+            Region.apnortheast3,
+            Region.apsouth1,
+            Region.apsouth2,
+            Region.apsoutheast1,
+            Region.apsoutheast2,
+            Region.apsoutheast3,
+            Region.apsoutheast4,
+            Region.apsoutheast5,
+            Region.apsoutheast7,
+            Region.cacentral1,
+            Region.cawest1,
+            Region.cnnorth1,
+            Region.cnnorthwest1,
+            Region.eucentral1,
+            Region.eucentral2,
+            Region.euisoewest1,
+            Region.eunorth1,
+            Region.eusouth1,
+            Region.eusouth2,
+            Region.euwest1,
+            Region.euwest2,
+            Region.euwest3,
+            Region.ilcentral1,
+            Region.mecentral1,
+            Region.mesouth1,
+            Region.mxcentral1,
+            Region.saeast1,
+            Region.useast1,
+            Region.useast2,
+            Region.usgoveast1,
+            Region.usgovwest1,
+            Region.usisoeast1,
+            Region.usisowest1,
+            Region.usisobeast1,
+            Region.usisofeast1,
+            Region.usisofsouth1,
+            Region.uswest1,
+            Region.uswest2,
+        ]
+    )
+    func crossRegionPrefixIsNoOp(region: Region) {
+        let id = BedrockModel.claude_mythos_v5.getModelIdWithCrossRegionInferencePrefix(region: region)
+        #expect(id == "anthropic.claude-mythos-5")
+    }
+}


### PR DESCRIPTION
## Summary

Add Claude Mythos 5 (`anthropic.claude-mythos-5`) to the Swift Bedrock Library with Messages API support via bedrock-mantle.

**⚠️ DO NOT MERGE — Model is in gated preview. Keeping this PR open until Claude Mythos 5 reaches GA.**

## Key characteristics

- **Endpoint:** bedrock-mantle only (Messages API at `/anthropic/v1/messages`)
- **Region:** us-east-1 only (no cross-region inference)
- **No Converse API** support
- **Temperature:** fixed at 1.0
- **TopP:** restricted to [0.99, 1.0)
- **Reasoning:** always enabled (adaptive), configurable effort
- **Context window:** 1M tokens, 128K max output

## Changes

- `Sources/BedrockService/Models/Anthropic/AnthropicGlobalModels.swift` — `Claude_Mythos_v5` struct
- `Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift` — `BedrockModel.claude_mythos_v5` constant
- `Sources/BedrockService/Models/BedrockModel.swift` — `init?(rawValue:)` case
- `Tests/Messages/MythosModelTests.swift` — unit + property-based tests
- `Examples/anthropic-mythos-messages/` — example project
- `.github/workflows/pull_request.yml` — CI integration

## Testing

- 22 unit tests + 4 property-based tests (cross-region no-op across 42 regions, temperature enforcement, topP enforcement, unknown rawValue resolution)
- All 347 project tests pass
- Example compiles but cannot be tested end-to-end until model access is granted (gated preview)

## Dependencies

Depends on #91 (DRY mantle URL helpers) being merged first.