### PR TITLE
Add xAI Grok 4.3 model support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,7 +109,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'anthropic-messages', 'api-key', 'converse', 'converse-stream', 'embeddings', 'google-gemma', 'openai-bedrock', 'openai-responses', 'retrieve', 'stability-image', 'structured-output', 'text_chat' ]"
+      examples: "[ 'anthropic-messages', 'api-key', 'converse', 'converse-stream', 'embeddings', 'google-gemma', 'openai-bedrock', 'openai-responses', 'retrieve', 'stability-image', 'structured-output', 'text_chat', 'xai-grok' ]"
 
   swift-6-language-mode:
     name: Swift 6 Language Mode

--- a/Examples/xai-grok/Package.swift
+++ b/Examples/xai-grok/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "XAIGrok",
+    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18)],
+    products: [
+        .executable(name: "XAIGrok", targets: ["XAIGrok"])
+    ],
+    dependencies: [
+        // for production use, uncomment the following line
+        // .package(url: "https://github.com/build-on-aws/swift-bedrock-library.git", branch: "main"),
+
+        // for local development, use the following line
+        .package(name: "swift-bedrock-library", path: "../.."),
+
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "XAIGrok",
+            dependencies: [
+                .product(name: "BedrockService", package: "swift-bedrock-library"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        )
+    ]
+)

--- a/Examples/xai-grok/Sources/Grok.swift
+++ b/Examples/xai-grok/Sources/Grok.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BedrockService
+import Foundation
+import Logging
+
+/// Demonstrates xAI Grok 4.3 text generation via the bedrock-mantle endpoint.
+///
+/// Grok 4.3 is **mantle-only** — it does NOT support InvokeModel or Converse
+/// on bedrock-runtime. All requests route through bedrock-mantle using either:
+/// - The Chat Completions API (`completeChatCompletion`)
+/// - The Responses API (`createResponse`)
+///
+/// Grok 4.3 is currently only available in `us-west-2`.
+@main
+struct Main {
+    static func main() async throws {
+        do {
+            try await Main.grok()
+        } catch {
+            print("Error:\n\(error)")
+        }
+    }
+
+    static func grok() async throws {
+        var logger = Logger(label: "XAIGrok")
+        logger.logLevel = .debug
+
+        print("xAI Grok 4.3 via bedrock-mantle")
+        print("================================")
+        print()
+        print("Choose authentication method:")
+        print("  1. API Key (set AWS_BEARER_TOKEN_BEDROCK environment variable)")
+        print("  2. SigV4 (uses default AWS credential provider chain)")
+        print()
+        print("Enter 1 or 2: ", terminator: "")
+
+        let choice = readLine()?.trimmingCharacters(in: .whitespaces) ?? "1"
+
+        let authentication: BedrockAuthentication
+        switch choice {
+        case "2":
+            print("Using SigV4 with default credential provider chain")
+            authentication = .default
+        default:
+            guard let apiKey = ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] else {
+                print("Error: Set AWS_BEARER_TOKEN_BEDROCK environment variable")
+                print("Create an API key at: https://console.aws.amazon.com/bedrock/home#/api-keys")
+                return
+            }
+            print("Using API Key authentication")
+            authentication = .apiKey(key: apiKey)
+        }
+
+        let bedrock = try await BedrockService(
+            region: .uswest2,
+            logger: logger
+        )
+
+        // --- Chat Completions API ---
+        let chatPrompt = "Explain the difference between a compiler and an interpreter in two sentences."
+
+        print()
+        print("--- Chat Completions API ---")
+        print("Prompt: \(chatPrompt)")
+        print()
+
+        let chatResponse = try await bedrock.completeChatCompletion(
+            chatPrompt,
+            with: .grok_4_3,
+            authentication: authentication
+        )
+
+        print("Response: \(chatResponse.text)")
+        print(
+            "Usage: \(chatResponse.usage.promptTokens) prompt + \(chatResponse.usage.completionTokens) completion = \(chatResponse.usage.totalTokens) total tokens"
+        )
+
+        // --- Responses API ---
+        let responsesPrompt = "What are three benefits of open-source software?"
+
+        print()
+        print("--- Responses API ---")
+        print("Prompt: \(responsesPrompt)")
+        print()
+
+        let responsesResponse = try await bedrock.createResponse(
+            responsesPrompt,
+            with: .grok_4_3,
+            authentication: authentication
+        )
+
+        print("Response: \(responsesResponse.text)")
+        print("Usage: \(responsesResponse.usage.inputTokens) in / \(responsesResponse.usage.outputTokens) out")
+    }
+}

--- a/Sources/BedrockService/Docs.docc/ChatCompletions.md
+++ b/Sources/BedrockService/Docs.docc/ChatCompletions.md
@@ -1,10 +1,10 @@
 # Chat Completions API
 
-Use Google Gemma models on Amazon Bedrock via the OpenAI-compatible Chat Completions API
+Use Google Gemma and xAI Grok models on Amazon Bedrock via the OpenAI-compatible Chat Completions API
 
 ## Overview
 
-The Chat Completions API provides access to Google Gemma models hosted on Amazon Bedrock through the `bedrock-mantle` endpoint. This API uses the OpenAI-compatible chat completions protocol and supports multi-turn conversations.
+The Chat Completions API provides access to Google Gemma and xAI Grok models hosted on Amazon Bedrock through the `bedrock-mantle` endpoint. This API uses the OpenAI-compatible chat completions protocol and supports multi-turn conversations.
 
 Like the Responses and Messages APIs, the Chat Completions API requires explicit authentication — you pass a ``BedrockAuthentication`` value directly to the call.
 
@@ -18,8 +18,9 @@ Like the Responses and Messages APIs, the Chat Completions API requires explicit
 | Gemma 3 27B IT | `.gemma3_27b_it` | `/v1/chat/completions` |
 | Gemma 3 12B IT | `.gemma3_12b_it` | `/v1/chat/completions` |
 | Gemma 3 4B IT | `.gemma3_4b_it` | `/v1/chat/completions` |
+| xAI Grok 4.3 | `.grok_4_3` | `/openai/v1/chat/completions` |
 
-> Note: Gemma 4 models are **mantle-only** — they support Chat Completions and Responses APIs but not InvokeModel or Converse. Gemma 3 models support Chat Completions, InvokeModel (``BedrockService/completeText(_:with:maxTokens:temperature:topP:topK:stopSequences:serviceTier:)``), and the Converse API.
+> Note: Gemma 4 and Grok 4.3 are **mantle-only** — they support Chat Completions and Responses APIs but not InvokeModel or Converse. Gemma 3 models support Chat Completions, InvokeModel (``BedrockService/completeText(_:with:maxTokens:temperature:topP:topK:stopSequences:serviceTier:)``), and the Converse API. Grok 4.3 is currently available only in `us-west-2`.
 
 ## Basic Usage
 
@@ -135,11 +136,22 @@ let reply = try await bedrock.completeChatCompletion(
 
 > Important: Temperature and top-p are mutually exclusive. Providing both throws a `notSupported` error. Top-k is not supported for Gemma models.
 
+Gemma parameter ranges and defaults:
+
 | Parameter | Range | Default |
 |-----------|-------|---------|
 | temperature | 0 – 2 | 1 |
 | maxTokens | 1 – 8192 | 8192 |
 | topP | 0 – 1 | 1 |
+| topK | — | Not supported |
+
+Grok 4.3 has different defaults (matching xAI's published values):
+
+| Parameter | Range | Default |
+|-----------|-------|---------|
+| temperature | 0 – 2 | 0.7 |
+| maxTokens | 1 – 131072 | 131072 |
+| topP | 0 – 1 | 0.95 |
 | topK | — | Not supported |
 
 ## Response Structure

--- a/Sources/BedrockService/Docs.docc/Responses.md
+++ b/Sources/BedrockService/Docs.docc/Responses.md
@@ -1,21 +1,25 @@
-# OpenAI Responses API
+# Responses API
 
-Use OpenAI models on Amazon Bedrock via the Responses API
+Use OpenAI, Google Gemma, and xAI Grok models on Amazon Bedrock via the Responses API
 
 ## Overview
 
-The Responses API provides access to OpenAI models hosted on Amazon Bedrock through the `bedrock-mantle` endpoint. This API uses a different protocol than the Converse API and supports models like GPT 5.5 and GPT 5.4.
+The Responses API provides access to OpenAI-compatible models hosted on Amazon Bedrock through the `bedrock-mantle` endpoint. This API uses a different protocol than the Converse API and supports models like GPT 5.5, GPT 5.4, Gemma 4, and Grok 4.3.
 
 The Responses API requires explicit authentication — you pass a ``BedrockAuthentication`` value directly to the call, supporting both API key (Bearer token) and SigV4 credential-based authentication.
 
 ## Supported Models
 
-The following OpenAI models support the Responses API:
+The following models support the Responses API:
 
 | Model | Identifier |
 |-------|-----------|
 | GPT 5.5 | `.openai_gpt_5_5` |
 | GPT 5.4 | `.openai_gpt_5_4` |
+| Gemma 4 31B | `.gemma4_31b` |
+| Gemma 4 26B-A4B | `.gemma4_26b_a4b` |
+| Gemma 4 E2B | `.gemma4_e2b` |
+| xAI Grok 4.3 | `.grok_4_3` |
 
 ## Basic Usage
 

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -144,6 +144,8 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
         case BedrockModel.gemma3_27b_it.id: self = BedrockModel.gemma3_27b_it
         case BedrockModel.gemma3_12b_it.id: self = BedrockModel.gemma3_12b_it
         case BedrockModel.gemma3_4b_it.id: self = BedrockModel.gemma3_4b_it
+        // xai
+        case BedrockModel.grok_4_3.id: self = BedrockModel.grok_4_3
         // stability
         case BedrockModel.stable_image_core.id: self = BedrockModel.stable_image_core
         case BedrockModel.stable_image_ultra.id: self = BedrockModel.stable_image_ultra

--- a/Sources/BedrockService/Models/xAI/xAI.swift
+++ b/Sources/BedrockService/Models/xAI/xAI.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+struct GrokText: ChatCompletionsModality, ResponsesModality {
+    let parameters: TextGenerationParameters
+
+    func getName() -> String { "xAI Grok Text Generation" }
+    func getChatCompletionsPath() -> String { "/openai/v1/chat/completions" }
+    func getResponsesPath() -> String { "/openai/v1/responses" }
+    func getTextGenerationParameters() -> TextGenerationParameters { parameters }
+}

--- a/Sources/BedrockService/Models/xAI/xAIBedrockModels.swift
+++ b/Sources/BedrockService/Models/xAI/xAIBedrockModels.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-3.html
+
+extension BedrockModel {
+    public static let grok_4_3: BedrockModel = BedrockModel(
+        id: "xai.grok-4.3",
+        name: "xAI Grok 4.3",
+        modality: GrokText(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 2, defaultValue: 0.7),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 131_072, defaultValue: 131_072),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 0.95),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+}

--- a/Tests/ChatCompletions/ChatCompletionsModelTests.swift
+++ b/Tests/ChatCompletions/ChatCompletionsModelTests.swift
@@ -478,4 +478,69 @@ struct ChatCompletionsModelTests {
             }
         }
     }
+
+    // MARK: - xAI Grok 4.3
+
+    @Test("Grok 4.3 has correct model ID")
+    func grok43ModelId() {
+        #expect(BedrockModel.grok_4_3.id == "xai.grok-4.3")
+    }
+
+    @Test("Grok 4.3 has correct name")
+    func grok43ModelName() {
+        #expect(BedrockModel.grok_4_3.name == "xAI Grok 4.3")
+    }
+
+    @Test("Grok 4.3 has chat completions modality")
+    func grok43HasChatCompletionsModality() {
+        #expect(BedrockModel.grok_4_3.hasChatCompletionsModality())
+    }
+
+    @Test("Grok 4.3 has responses modality")
+    func grok43HasResponsesModality() {
+        #expect(BedrockModel.grok_4_3.hasResponsesModality())
+    }
+
+    @Test("Grok 4.3 does not have text, converse, messages, or image modality")
+    func grok43NoOtherModalities() {
+        #expect(!BedrockModel.grok_4_3.hasTextModality())
+        #expect(!BedrockModel.grok_4_3.hasConverseModality())
+        #expect(!BedrockModel.grok_4_3.hasMessagesModality())
+        #expect(!BedrockModel.grok_4_3.hasImageModality())
+    }
+
+    @Test("Grok 4.3 uses /openai/v1/chat/completions path")
+    func grok43ChatCompletionsPath() throws {
+        let modality = try BedrockModel.grok_4_3.getChatCompletionsModality()
+        #expect(modality.getChatCompletionsPath() == "/openai/v1/chat/completions")
+    }
+
+    @Test("Grok 4.3 uses /openai/v1/responses path")
+    func grok43ResponsesPath() throws {
+        let modality = try BedrockModel.grok_4_3.getResponsesModality()
+        #expect(modality.getResponsesPath() == "/openai/v1/responses")
+    }
+
+    @Test("Grok 4.3 is resolvable from rawValue")
+    func grok43RawValue() {
+        let model = BedrockModel(rawValue: "xai.grok-4.3")
+        #expect(model != nil)
+        #expect(model?.name == "xAI Grok 4.3")
+    }
+
+    @Test("Grok 4.3 parameter defaults match model card")
+    func grok43ParameterDefaults() throws {
+        let modality = try BedrockModel.grok_4_3.getChatCompletionsModality()
+        let params = modality.getTextGenerationParameters()
+        #expect(params.temperature.defaultValue == 0.7)
+        #expect(params.temperature.minValue == 0)
+        #expect(params.temperature.maxValue == 2)
+        #expect(params.topP.defaultValue == 0.95)
+        #expect(params.topP.minValue == 0)
+        #expect(params.topP.maxValue == 1)
+        #expect(params.maxTokens.defaultValue == 131_072)
+        #expect(params.maxTokens.minValue == 1)
+        #expect(params.maxTokens.maxValue == 131_072)
+        #expect(!params.topK.isSupported)
+    }
 }

--- a/Tests/ChatCompletions/ChatCompletionsServiceTests.swift
+++ b/Tests/ChatCompletions/ChatCompletionsServiceTests.swift
@@ -145,4 +145,23 @@ struct ChatCompletionsServiceTests {
             )
         }
     }
+
+    // MARK: - completeChatCompletion (Grok 4.3)
+
+    @Test("completeChatCompletion with Grok 4.3 returns correct output")
+    func completeChatCompletionGrok43() async throws {
+        let output = try await bedrock.completeChatCompletion(
+            "Hello from Grok",
+            with: .grok_4_3,
+            authentication: .apiKey(key: "test-key"),
+            mantleClient: MockBedrockMantleChatCompletionsClient()
+        )
+
+        #expect(output.text == "Mock completion for: Hello from Grok")
+        #expect(output.model == "xai.grok-4.3")
+        #expect(output.id == "chatcmpl-mock")
+        #expect(output.usage.promptTokens == 5)
+        #expect(output.usage.completionTokens == 10)
+        #expect(output.usage.totalTokens == 15)
+    }
 }

--- a/Tests/Responses/ResponsesServiceTests.swift
+++ b/Tests/Responses/ResponsesServiceTests.swift
@@ -84,4 +84,20 @@ struct ResponsesServiceTests {
             )
         }
     }
+
+    @Test("createResponse with Grok 4.3 returns text")
+    func createResponseGrok43() async throws {
+        let output = try await bedrock.createResponse(
+            "Tell me about Grok",
+            with: .grok_4_3,
+            authentication: .apiKey(key: "test-key"),
+            mantleClient: MockBedrockMantleClient()
+        )
+
+        #expect(output.text == "Mock response for: Tell me about Grok")
+        #expect(output.model == .grok_4_3)
+        #expect(output.id == "resp_mock_123")
+        #expect(output.usage.inputTokens == 10)
+        #expect(output.usage.outputTokens == 20)
+    }
 }

--- a/parameter_cheatsheet.md
+++ b/parameter_cheatsheet.md
@@ -127,6 +127,24 @@
 | ------------- | ------------- | ------------- |
 | stopSequences | Not supported | Not supported |
 
+### xAI Grok
+
+[user guide](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-3.html)
+
+Grok 4.3 is mantle-only (Chat Completions + Responses APIs). Currently available in `us-west-2` only. Context window: 1,000,000 tokens.
+
+| parameter   | minValue      | maxValue      | defaultValue  | optional or required |
+| ----------- | ------------- | ------------- | ------------- | -------------------- |
+| temperature | 0             | 2             | 0.7           | optional             |
+| maxTokens   | 1             | 131_072       | 131_072       | optional             |
+| topP        | 0             | 1             | 0.95          | optional             |
+| topK        | Not supported | Not supported | Not supported | optional             |
+
+
+| parameter     | maxSequences  | defaultVal    |
+| ------------- | ------------- | ------------- |
+| stopSequences | Not supported | Not supported |
+
 
 ## Image Generation parameters
 


### PR DESCRIPTION
## Summary

- Adds support for **xAI Grok 4.3** (`xai.grok-4.3`) on Amazon Bedrock via the `bedrock-mantle` endpoint
- The new `GrokText` modality conforms to `ChatCompletionsModality` + `ResponsesModality`, mirroring the Gemma 4 shape introduced in #90
- Parameter defaults match the AWS model card: `temperature=0.7`, `top_p=0.95`, `max_completion_tokens=131_072`, 1M-token context window
- Currently only available in `us-west-2`; no cross-region inference profiles

## What's included

- `Sources/BedrockService/Models/xAI/xAI.swift` — `GrokText` modality struct
- `Sources/BedrockService/Models/xAI/xAIBedrockModels.swift` — `BedrockModel.grok_4_3` constant
- `BedrockModel.init?(rawValue:)` — registers `xai.grok-4.3`
- `Examples/xai-grok/` — runnable example covering Chat Completions and Responses APIs
- Unit tests in `Tests/ChatCompletions/` and `Tests/Responses/` covering model metadata, modality checks, paths, parameter defaults, and service-level calls
- Doc updates: `ChatCompletions.md`, `Responses.md`, `parameter_cheatsheet.md`
- CI: `xai-grok` added to the `pull_request.yml` examples list

## Out of scope

- `reasoning.effort` parameter wiring — would require a public API surface change across all mantle models; tracked separately
- Cross-region inference — Grok 4.3 has neither geo nor global inference profiles today

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (331 tests including 11 new Grok tests)
- [x] `cd Examples/xai-grok && swift build` passes
- [x] `swift format` applied
- [x] Manual smoke test in `us-west-2` with real credentials (optional)