### PR TITLE
Add MiniMax model support (M2, M2.1, M2.5)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,7 +109,7 @@ jobs:
       # We pass the list of examples here, but we can't pass an array as argument
       # Instead, we pass a String with a valid JSON array.
       # The workaround is mentioned here https://github.com/orgs/community/discussions/11692
-      examples: "[ 'anthropic-messages', 'api-key', 'converse', 'converse-stream', 'embeddings', 'google-gemma', 'openai-bedrock', 'openai-responses', 'retrieve', 'stability-image', 'structured-output', 'text_chat', 'xai-grok' ]"
+      examples: "[ 'anthropic-messages', 'api-key', 'converse', 'converse-stream', 'embeddings', 'google-gemma', 'minimax', 'openai-bedrock', 'openai-responses', 'retrieve', 'stability-image', 'structured-output', 'text_chat', 'xai-grok' ]"
 
   swift-6-language-mode:
     name: Swift 6 Language Mode

--- a/.kiro/specs/minimax-model-support/.config.kiro
+++ b/.kiro/specs/minimax-model-support/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "bbe003f1-1393-4ad0-9a15-1dbcd7e05cc3", "workflowType": "fast-task", "specType": "feature"}

--- a/.kiro/specs/minimax-model-support/design.md
+++ b/.kiro/specs/minimax-model-support/design.md
@@ -1,0 +1,355 @@
+# Design Document: MiniMax Model Support
+
+## Overview
+
+This design adds three MiniMax models to the Swift Bedrock Library. All three models use both the Anthropic Messages API format and the Chat Completions API format, routing through the bedrock-mantle endpoint. The implementation conforms to both `MessagesModality` and `ChatCompletionsModality`, reusing the existing `createMessage` and `completeChatCompletion` infrastructure.
+
+**Models:**
+- `minimax_m2` — MiniMax M2, 1M token context, 8K max output
+- `minimax_m2_1` — MiniMax M2.1, 196K token context, 8K max output
+- `minimax_m2_5` — MiniMax M2.5, 196K token context, 8K max output
+
+The implementation introduces:
+1. A new `Sources/BedrockService/Models/MiniMax/` provider directory
+2. A `MiniMaxText` modality struct conforming to both `MessagesModality` and `ChatCompletionsModality`
+3. Three `BedrockModel` static constants
+4. Two example projects: `Examples/minimax-messages/` and `Examples/minimax-chatcompletions/`
+
+No new protocols, service methods, or request/response types are needed — MiniMax models plug directly into the existing Messages and Chat Completions infrastructure.
+
+## Architecture
+
+### Endpoint Routing
+
+```mermaid
+graph TD
+    subgraph "bedrock-mantle"
+        MM[MessagesModality] --> CMM["createMessage()"]
+        CCM[ChatCompletionsModality] --> CCC["completeChatCompletion()"]
+    end
+
+    MX[MiniMax models] --> MM
+    MX --> CCM
+    MX -.->|NOT supported| TM[TextModality]
+    MX -.->|NOT supported| CM[ConverseModality]
+    MX -.->|NOT supported| RM[ResponsesModality]
+    MX -.->|NOT supported| CRI[CrossRegionInferenceModality]
+```
+
+### Modality Struct Design
+
+```mermaid
+classDiagram
+    class Modality {
+        <<protocol>>
+        +getName() String
+    }
+    class MessagesModality {
+        <<protocol>>
+        +getMessagesPath() String
+    }
+    class ChatCompletionsModality {
+        <<protocol>>
+        +getChatCompletionsPath() String
+        +getTextGenerationParameters() TextGenerationParameters
+    }
+
+    Modality <|-- MessagesModality
+    Modality <|-- ChatCompletionsModality
+
+    class MiniMaxText {
+        +parameters: TextGenerationParameters
+        +getName() String
+        +getMessagesPath() String
+        +getChatCompletionsPath() String
+        +getTextGenerationParameters() TextGenerationParameters
+    }
+
+    MessagesModality <|.. MiniMaxText
+    ChatCompletionsModality <|.. MiniMaxText
+```
+
+### Key Architectural Decisions
+
+1. **MessagesModality + ChatCompletionsModality**: MiniMax models conform to both protocols. This means they can be used with both `createMessage` (Anthropic Messages format) and `completeChatCompletion` (OpenAI Chat Completions format). This is similar to how xAI Grok conforms to `ChatCompletionsModality + ResponsesModality`, but MiniMax uses `MessagesModality + ChatCompletionsModality` instead.
+
+2. **Reuses all existing infrastructure**: The `createMessage` method already handles `MessagesModality` models by building `MessagesRequestBody`, sending to bedrock-mantle at the path returned by `getMessagesPath()`, and decoding `MessagesOutput`. Similarly, `completeChatCompletion` handles `ChatCompletionsModality` models by building `ChatCompletionsRequestBody`, sending to bedrock-mantle at the path returned by `getChatCompletionsPath()`, and decoding `ChatCompletionsOutput`. MiniMax plugs directly into both.
+
+3. **No cross-region inference**: MiniMax models are in-region only. The `MiniMaxText` struct does NOT conform to `CrossRegionInferenceModality` or `GlobalCrossRegionInferenceModality`, so `getModelIdWithCrossRegionInferencePrefix` returns the plain model ID.
+
+4. **Parameter structure**: All three models share identical parameter ranges. The `TextGenerationParameters` struct captures temperature [0, 1], maxTokens [1, 8192], topP [0, 1], topK not supported, stopSequences not supported.
+
+5. **Pattern follows xAI Grok**: The file structure (modality struct + BedrockModels file) mirrors the xAI directory. The dual-protocol conformance mirrors how `GrokText` conforms to `ChatCompletionsModality + ResponsesModality`, but `MiniMaxText` conforms to `MessagesModality + ChatCompletionsModality`.
+
+## Components and Interfaces
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `Sources/BedrockService/Models/MiniMax/MiniMax.swift` | `MiniMaxText` modality struct |
+| `Sources/BedrockService/Models/MiniMax/MiniMaxBedrockModels.swift` | Three `BedrockModel` static constants |
+| `Examples/minimax-messages/Package.swift` | Messages example package manifest |
+| `Examples/minimax-messages/Sources/MiniMaxMessages.swift` | Example demonstrating `createMessage` with MiniMax |
+| `Examples/minimax-chatcompletions/Package.swift` | Chat Completions example package manifest |
+| `Examples/minimax-chatcompletions/Sources/MiniMaxChatCompletions.swift` | Example demonstrating `completeChatCompletion` with MiniMax |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `Sources/BedrockService/Models/BedrockModel.swift` | Add three new cases in `init?(rawValue:)` |
+| `.github/workflows/pull_request.yml` | Add `'minimax-messages'` and `'minimax-chatcompletions'` to examples list |
+
+### `MiniMaxText` Struct
+
+```swift
+struct MiniMaxText: MessagesModality, ChatCompletionsModality {
+    let parameters: TextGenerationParameters
+
+    func getName() -> String { "MiniMax Text Generation" }
+    func getMessagesPath() -> String { "/anthropic/v1/messages" }
+    func getChatCompletionsPath() -> String { "/v1/chat/completions" }
+    func getTextGenerationParameters() -> TextGenerationParameters { parameters }
+}
+```
+
+This struct conforms to both `MessagesModality` and `ChatCompletionsModality`. It provides paths for both the Anthropic Messages API and the OpenAI Chat Completions API endpoints, and exposes `TextGenerationParameters` as required by `ChatCompletionsModality`.
+
+### `BedrockModel` Static Constants
+
+```swift
+extension BedrockModel {
+    public static let minimax_m2: BedrockModel = BedrockModel(
+        id: "minimax.minimax-m2",
+        name: "MiniMax M2",
+        modality: MiniMaxText(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+
+    public static let minimax_m2_1: BedrockModel = BedrockModel(
+        id: "minimax.minimax-m2.1",
+        name: "MiniMax M2.1",
+        modality: MiniMaxText(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+
+    public static let minimax_m2_5: BedrockModel = BedrockModel(
+        id: "minimax.minimax-m2.5",
+        name: "MiniMax M2.5",
+        modality: MiniMaxText(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8192, defaultValue: 8192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+}
+```
+
+### `BedrockModel.init?(rawValue:)` Additions
+
+```swift
+// minimax
+case BedrockModel.minimax_m2.id: self = BedrockModel.minimax_m2
+case BedrockModel.minimax_m2_1.id: self = BedrockModel.minimax_m2_1
+case BedrockModel.minimax_m2_5.id: self = BedrockModel.minimax_m2_5
+```
+
+### Protocol Conformance Summary
+
+| Check | MiniMax (all 3) |
+|-------|-----------------|
+| `hasMessagesModality()` | `true` |
+| `hasChatCompletionsModality()` | `true` |
+| `hasTextModality()` | `false` |
+| `hasConverseModality()` | `false` |
+| `hasResponsesModality()` | `false` |
+| `hasImageModality()` | `false` |
+
+## Data Models
+
+### Text Generation Parameters
+
+All three models share identical parameter ranges:
+
+| Parameter | Min | Max | Default | Supported |
+|-----------|-----|-----|---------|-----------|
+| temperature | 0 | 1 | 1 | Yes |
+| maxTokens | 1 | 8192 | 8192 | Yes |
+| topP | 0 | 1 | 1 | Yes |
+| topK | — | — | — | No |
+| stopSequences | — | — | — | No |
+
+### Model Identifiers
+
+| Model | ID | Name | Messages Path | Chat Completions Path |
+|-------|-----|------|---------------|-----------------------|
+| MiniMax M2 | `minimax.minimax-m2` | MiniMax M2 | `/anthropic/v1/messages` | `/v1/chat/completions` |
+| MiniMax M2.1 | `minimax.minimax-m2.1` | MiniMax M2.1 | `/anthropic/v1/messages` | `/v1/chat/completions` |
+| MiniMax M2.5 | `minimax.minimax-m2.5` | MiniMax M2.5 | `/anthropic/v1/messages` | `/v1/chat/completions` |
+
+### Wire Format — Messages API (Existing — No Changes Needed)
+
+MiniMax models use the existing `MessagesRequestBody` and `MessagesOutput` types already defined for Claude Fable 5.
+
+**Request** (existing `MessagesRequestBody`):
+```json
+{
+  "model": "minimax.minimax-m2",
+  "max_tokens": 8192,
+  "messages": [{"role": "user", "content": "Hello"}]
+}
+```
+
+**Response** (existing `MessagesRawOutput` → `MessagesOutput`):
+```json
+{
+  "id": "msg_abc123",
+  "type": "message",
+  "role": "assistant",
+  "content": [{"type": "text", "text": "Generated text here"}],
+  "model": "minimax.minimax-m2",
+  "usage": {"input_tokens": 10, "output_tokens": 20}
+}
+```
+
+### Wire Format — Chat Completions API (Existing — No Changes Needed)
+
+MiniMax models use the existing `ChatCompletionsRequestBody` and `ChatCompletionsOutput` types.
+
+**Request** (existing `ChatCompletionsRequestBody`):
+```json
+{
+  "model": "minimax.minimax-m2",
+  "max_tokens": 8192,
+  "messages": [{"role": "user", "content": "Hello"}]
+}
+```
+
+**Response** (existing `ChatCompletionsOutput`):
+```json
+{
+  "id": "chatcmpl-abc123",
+  "object": "chat.completion",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "Generated text here"}}],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+}
+```
+
+## Correctness Properties
+
+### Property 1: Unknown raw values resolve to nil
+
+*For any* string that does not match any known model ID in the library, `BedrockModel(rawValue:)` SHALL return nil.
+
+**Validates: Requirements 1.6**
+
+### Property 2: MiniMax models resolve from rawValue round-trip
+
+*For any* of the three MiniMax model IDs (`minimax.minimax-m2`, `minimax.minimax-m2.1`, `minimax.minimax-m2.5`), constructing a `BedrockModel` via `init?(rawValue:)` SHALL return a non-nil instance whose `id` property equals the original raw value string.
+
+**Validates: Requirements 1.5, 2.4, 3.4**
+
+### Property 3: MiniMax models have consistent messages path
+
+*For any* of the three MiniMax models, calling `getMessagesModality()` SHALL succeed and the returned modality's `getMessagesPath()` SHALL always equal `/anthropic/v1/messages`.
+
+**Validates: Requirements 1.3, 2.2, 3.2, 6.1**
+
+### Property 4: MiniMax models have consistent chat completions path
+
+*For any* of the three MiniMax models, calling `getChatCompletionsModality()` SHALL succeed and the returned modality's `getChatCompletionsPath()` SHALL always equal `/v1/chat/completions`.
+
+**Validates: Requirements 1.4, 2.3, 3.3, 7.1**
+
+### Property 5: MiniMax models do not have unsupported modalities
+
+*For any* of the three MiniMax models, `hasTextModality()`, `hasConverseModality()`, `hasResponsesModality()`, and `hasImageModality()` SHALL all return false.
+
+**Validates: Requirements 5.3, 5.4, 5.5, 5.6**
+
+### Property 6: Cross-region inference returns plain model ID
+
+*For any* of the three MiniMax models and *for any* valid AWS region, `getModelIdWithCrossRegionInferencePrefix(region:)` SHALL return the model ID without any prefix (equal to the model's `id` property).
+
+**Validates: Requirements 8.1, 8.2**
+
+## Error Handling
+
+| Scenario | Error | Message |
+|----------|-------|---------|
+| `getTextModality()` on MiniMax model | `BedrockLibraryError.invalidModality` | "Model {id} does not support text generation" |
+| `getConverseModality()` on MiniMax model | `BedrockLibraryError.invalidModality` | "Model {id} does not support text generation" |
+| `getResponsesModality()` on MiniMax model | `BedrockLibraryError.invalidModality` | "Model {id} does not support the Responses API" |
+| `getImageModality()` on MiniMax model | `BedrockLibraryError.invalidModality` | "Model {id} does not support image generation" |
+| `createMessage` with model lacking MessagesModality | `BedrockLibraryError.invalidModality` | "Model {id} does not support the Messages API" |
+| `completeChatCompletion` with model lacking ChatCompletionsModality | `BedrockLibraryError.invalidModality` | "Model {id} does not support the Chat Completions API" |
+
+## Testing Strategy
+
+### Test Framework
+
+All tests use Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) as per project conventions. Run with `swift test`.
+
+### Unit Tests (Example-Based)
+
+Organized in `Tests/Messages/MiniMaxMessagesModelTests.swift`:
+
+Coverage:
+- All 3 model constants (ID, name)
+- `hasMessagesModality()` returns true for all 3
+- `hasChatCompletionsModality()` returns true for all 3
+- `hasTextModality()` returns false for all 3
+- `hasConverseModality()` returns false for all 3
+- `hasResponsesModality()` returns false for all 3
+- `hasImageModality()` returns false for all 3
+- Messages path value (`/anthropic/v1/messages`) for all 3
+- Chat Completions path value (`/v1/chat/completions`) for all 3
+- Raw value initialization for all 3 models
+- Unknown raw value → nil
+- Error throws for unsupported modality access (`getTextModality`, `getConverseModality`, `getResponsesModality`)
+- Cross-region inference returns plain ID (no prefix)
+
+### Integration Tests (with Mocks)
+
+Using existing mock clients:
+
+- `createMessage` with MiniMax M2 model → correct response (using `MockBedrockMantleMessagesClient`)
+- `createMessage` with MiniMax M2.5 model → correct response
+- `completeChatCompletion` with MiniMax M2 model → correct response (using `MockBedrockMantleChatCompletionsClient`)
+- `createMessage` throws `invalidModality` for models without MessagesModality
+- `completeChatCompletion` throws `invalidModality` for models without ChatCompletionsModality
+
+### Property-Based Tests
+
+Using Swift Testing's `@Test(..., arguments:)` with generated value arrays:
+
+| Property | Test Location | Strategy |
+|----------|--------------|----------|
+| 1: Unknown raw values → nil | `MiniMaxMessagesModelTests` | Generate 100 random UUID strings, verify all return nil from `BedrockModel(rawValue:)` |
+| 2: rawValue round-trip | `MiniMaxMessagesModelTests` | Verify all 3 MiniMax model IDs resolve correctly |
+| 3: Consistent messages path | `MiniMaxMessagesModelTests` | Verify all 3 models return `/anthropic/v1/messages` |
+| 4: Consistent chat completions path | `MiniMaxMessagesModelTests` | Verify all 3 models return `/v1/chat/completions` |
+| 5: No unsupported modalities | `MiniMaxMessagesModelTests` | Verify all 4 unsupported modality checks return false for all 3 models |
+| 6: Plain model ID for cross-region | `MiniMaxMessagesModelTests` | Verify all 3 models across multiple regions return plain ID |

--- a/.kiro/specs/minimax-model-support/requirements.md
+++ b/.kiro/specs/minimax-model-support/requirements.md
@@ -1,0 +1,148 @@
+# Requirements Document
+
+## Introduction
+
+Add support for MiniMax models to the Swift Bedrock Library. MiniMax models use both the Anthropic Messages API format (at `/anthropic/v1/messages`) and the Chat Completions API format (at `/v1/chat/completions`), routing through the bedrock-mantle endpoint. The implementation introduces a `MiniMax/` provider directory with a `MiniMaxText` modality struct conforming to both `MessagesModality` and `ChatCompletionsModality`, and defines model constants for all three MiniMax variants.
+
+## Glossary
+
+- **Bedrock_Mantle**: The cross-model inference endpoint (`bedrock-mantle.{region}.api.aws`) used by models that expose OpenAI-compatible or Anthropic-compatible APIs
+- **MessagesModality**: A protocol for models supporting the Anthropic Messages API on bedrock-mantle, requiring a `getMessagesPath() -> String` method
+- **ChatCompletionsModality**: A protocol for models supporting the Chat Completions API on bedrock-mantle, requiring `getChatCompletionsPath() -> String` and `getTextGenerationParameters() -> TextGenerationParameters` methods
+- **MiniMax_M2**: MiniMax's M2 model with a 1M token context window and 8K max output tokens
+- **MiniMax_M2_1**: MiniMax's M2.1 model with a 196K token context window and 8K max output tokens
+- **MiniMax_M2_5**: MiniMax's M2.5 model with a 196K token context window and 8K max output tokens
+- **BedrockModel**: The central type in the Swift Bedrock Library representing a model with its ID, name, and modality configuration
+- **Modality**: A protocol defining the capabilities of a model (text generation, image, embeddings, responses, messages, chat completions, etc.)
+- **createMessage**: The existing `BedrockService` method that handles MessagesModality models — builds the request using `MessagesRequestBody`, sends to bedrock-mantle, and returns `MessagesOutput`
+- **completeChatCompletion**: The existing `BedrockService` method that handles ChatCompletionsModality models — builds the request using `ChatCompletionsRequestBody`, sends to bedrock-mantle, and returns `ChatCompletionsOutput`
+
+## Requirements
+
+### Requirement 1: Model Definition for MiniMax M2
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for MiniMax M2, so that I can reference it when making API calls via the Messages API or Chat Completions API.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `minimax_m2` with model ID `"minimax.minimax-m2"`
+2. THE BedrockModel `minimax_m2` SHALL have the display name `"MiniMax M2"`
+3. THE BedrockModel `minimax_m2` SHALL support MessagesModality with the path `/anthropic/v1/messages`
+4. THE BedrockModel `minimax_m2` SHALL support ChatCompletionsModality with the path `/v1/chat/completions`
+5. WHEN the raw value `"minimax.minimax-m2"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `minimax_m2` instance
+6. IF a raw value other than any known model ID is provided to `BedrockModel(rawValue:)`, THEN THE BedrockModel initializer SHALL return nil
+
+### Requirement 2: Model Definition for MiniMax M2.1
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for MiniMax M2.1, so that I can reference it when making API calls via the Messages API or Chat Completions API.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `minimax_m2_1` with model ID `"minimax.minimax-m2.1"` and display name `"MiniMax M2.1"`
+2. THE BedrockModel `minimax_m2_1` SHALL support MessagesModality with the path `/anthropic/v1/messages`
+3. THE BedrockModel `minimax_m2_1` SHALL support ChatCompletionsModality with the path `/v1/chat/completions`
+4. WHEN the raw value `"minimax.minimax-m2.1"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `minimax_m2_1` instance
+
+### Requirement 3: Model Definition for MiniMax M2.5
+
+**User Story:** As a developer using the Swift Bedrock Library, I want a `BedrockModel` static constant for MiniMax M2.5, so that I can reference it when making API calls via the Messages API or Chat Completions API.
+
+#### Acceptance Criteria
+
+1. THE BedrockModel SHALL expose a public static constant named `minimax_m2_5` with model ID `"minimax.minimax-m2.5"` and display name `"MiniMax M2.5"`
+2. THE BedrockModel `minimax_m2_5` SHALL support MessagesModality with the path `/anthropic/v1/messages`
+3. THE BedrockModel `minimax_m2_5` SHALL support ChatCompletionsModality with the path `/v1/chat/completions`
+4. WHEN the raw value `"minimax.minimax-m2.5"` is provided to `BedrockModel(rawValue:)`, THE BedrockModel initializer SHALL return the `minimax_m2_5` instance
+
+### Requirement 4: MiniMax Text Generation Parameters
+
+**User Story:** As a developer, I want the MiniMax models to expose appropriate text generation parameters, so that I can control inference behavior when calling `createMessage` or `completeChatCompletion`.
+
+#### Acceptance Criteria
+
+1. ALL MiniMax models SHALL support the temperature parameter with a minimum value of 0, maximum value of 1, and default value of 1
+2. ALL MiniMax models SHALL support the maxTokens parameter with a minimum value of 1, maximum value of 8192, and default value of 8192
+3. ALL MiniMax models SHALL support the topP parameter with a minimum value of 0, maximum value of 1, and default value of 1
+4. ALL MiniMax models SHALL mark the topK parameter as not supported
+5. ALL MiniMax models SHALL mark the stopSequences parameter as not supported
+
+### Requirement 5: Unsupported Modalities for MiniMax Models
+
+**User Story:** As a developer, I want clear indication of which APIs MiniMax models support, so that I understand the available capabilities.
+
+#### Acceptance Criteria
+
+1. ALL MiniMax models SHALL report `hasMessagesModality()` as true
+2. ALL MiniMax models SHALL report `hasChatCompletionsModality()` as true
+3. ALL MiniMax models SHALL report `hasTextModality()` as false
+4. ALL MiniMax models SHALL report `hasConverseModality()` as false
+5. ALL MiniMax models SHALL report `hasResponsesModality()` as false
+6. ALL MiniMax models SHALL report `hasImageModality()` as false
+7. IF `getTextModality()` is called on a MiniMax model, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+8. IF `getConverseModality()` is called on a MiniMax model, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+9. IF `getResponsesModality()` is called on a MiniMax model, THEN THE Library SHALL throw a `BedrockLibraryError.invalidModality` error
+
+### Requirement 6: MiniMax Messages API Request Routing
+
+**User Story:** As a developer, I want MiniMax model requests to be correctly routed to the bedrock-mantle endpoint using the Anthropic Messages path, so that inference calls reach the correct API.
+
+#### Acceptance Criteria
+
+1. WHEN `createMessage` is called with a MiniMax model, THE Library SHALL send the request to `https://bedrock-mantle.{region}.api.aws/anthropic/v1/messages` where `{region}` is the region configured on the BedrockService instance
+2. WHEN `createMessage` is called with a MiniMax model, THE Library SHALL format the request body using the existing `MessagesRequestBody` structure (model ID, maxTokens, messages array)
+3. WHEN `createMessage` is called with a MiniMax model, THE Library SHALL support both API key and SigV4 authentication via the `BedrockAuthentication` parameter
+
+### Requirement 7: MiniMax Chat Completions API Request Routing
+
+**User Story:** As a developer, I want MiniMax model requests to be correctly routed to the bedrock-mantle endpoint using the Chat Completions path, so that I can use the OpenAI-compatible API format.
+
+#### Acceptance Criteria
+
+1. WHEN `completeChatCompletion` is called with a MiniMax model, THE Library SHALL send the request to `https://bedrock-mantle.{region}.api.aws/v1/chat/completions` where `{region}` is the region configured on the BedrockService instance
+2. WHEN `completeChatCompletion` is called with a MiniMax model, THE Library SHALL format the request body using the existing `ChatCompletionsRequestBody` structure
+3. WHEN `completeChatCompletion` is called with a MiniMax model, THE Library SHALL support both API key and SigV4 authentication via the `BedrockAuthentication` parameter
+
+### Requirement 8: No Cross-Region Inference for MiniMax Models
+
+**User Story:** As a developer, I want to understand that MiniMax models only support in-region inference, so that I do not attempt cross-region usage.
+
+#### Acceptance Criteria
+
+1. ALL MiniMax models SHALL NOT conform to `CrossRegionInferenceModality`
+2. WHEN `getModelIdWithCrossRegionInferencePrefix(region:)` is called on a MiniMax model, THE method SHALL return the model ID without any prefix
+
+### Requirement 9: Source File Organization
+
+**User Story:** As a contributor to the Swift Bedrock Library, I want MiniMax model source files organized in a dedicated MiniMax directory, so that the codebase remains consistent with the existing model provider structure.
+
+#### Acceptance Criteria
+
+1. THE Library SHALL contain a `Sources/BedrockService/Models/MiniMax/` directory for MiniMax model files
+2. THE Library SHALL contain a `MiniMaxBedrockModels.swift` file in the MiniMax directory defining all three model static constants (`minimax_m2`, `minimax_m2_1`, `minimax_m2_5`) as extensions on `BedrockModel`
+3. THE Library SHALL contain a `MiniMax.swift` file in the MiniMax directory defining the `MiniMaxText` modality struct conforming to both `MessagesModality` and `ChatCompletionsModality`
+4. THE `MiniMax.swift` file SHALL follow the same structural pattern as existing provider modality files (e.g., `xAI.swift`)
+
+### Requirement 10: Messages Example Project
+
+**User Story:** As a developer evaluating the Swift Bedrock Library, I want a working example project demonstrating how to use MiniMax models with `createMessage`, so that I can quickly understand the Messages API integration pattern.
+
+#### Acceptance Criteria
+
+1. THE Library SHALL contain an `Examples/minimax-messages/` directory with a complete executable Swift package
+2. THE example SHALL use `BedrockService.createMessage` with a MiniMax model via the bedrock-mantle endpoint
+3. THE example SHALL support both API key and SigV4 authentication methods
+4. THE example SHALL demonstrate a multi-turn conversation (at least two turns)
+5. THE example SHALL follow the same code structure and pattern as `Examples/anthropic-messages/`
+6. THE example SHALL be included in the CI integration tests examples list in `.github/workflows/pull_request.yml`
+
+### Requirement 11: Chat Completions Example Project
+
+**User Story:** As a developer evaluating the Swift Bedrock Library, I want a working example project demonstrating how to use MiniMax models with `completeChatCompletion`, so that I can quickly understand the Chat Completions API integration pattern.
+
+#### Acceptance Criteria
+
+1. THE Library SHALL contain an `Examples/minimax-chatcompletions/` directory with a complete executable Swift package
+2. THE example SHALL use `BedrockService.completeChatCompletion` with `.minimax_m2` via the bedrock-mantle endpoint
+3. THE example SHALL support both API key and SigV4 authentication methods
+4. THE example SHALL follow the same code structure and pattern as `Examples/xai-grok/`
+5. THE example SHALL be included in the CI integration tests examples list in `.github/workflows/pull_request.yml`

--- a/.kiro/specs/minimax-model-support/tasks.md
+++ b/.kiro/specs/minimax-model-support/tasks.md
@@ -1,0 +1,195 @@
+# Implementation Plan: MiniMax Model Support
+
+## Overview
+
+Add three MiniMax models to the Swift Bedrock Library by creating a `MiniMax/` provider directory with a `MiniMaxText` modality struct conforming to both `MessagesModality` and `ChatCompletionsModality`, defining model constants, adding `rawValue` resolution, writing tests, and creating two example projects (Messages and Chat Completions). The implementation reuses the existing `createMessage` and `completeChatCompletion` infrastructure — no new protocols or service methods are needed.
+
+## Tasks
+
+- [ ] 1. Create MiniMax provider directory and modality struct
+  - [ ] 1.1 Create `Sources/BedrockService/Models/MiniMax/MiniMax.swift` with `MiniMaxText` struct
+    - Define `MiniMaxText` conforming to both `MessagesModality` and `ChatCompletionsModality`
+    - `getName()` returns `"MiniMax Text Generation"`
+    - `getMessagesPath()` returns `"/anthropic/v1/messages"`
+    - `getChatCompletionsPath()` returns `"/v1/chat/completions"`
+    - `getTextGenerationParameters()` returns `parameters`
+    - Store `parameters: TextGenerationParameters` property
+    - Include the standard license header and `#if canImport(FoundationEssentials)` import guard
+    - Follow the structural pattern of `Sources/BedrockService/Models/xAI/xAI.swift`
+    - _Requirements: 9.3, 9.4_
+
+  - [ ] 1.2 Create `Sources/BedrockService/Models/MiniMax/MiniMaxBedrockModels.swift` with three model static constants
+    - Define `minimax_m2` (id: `minimax.minimax-m2`, name: `MiniMax M2`, modality: `MiniMaxText`)
+    - Define `minimax_m2_1` (id: `minimax.minimax-m2.1`, name: `MiniMax M2.1`, modality: `MiniMaxText`)
+    - Define `minimax_m2_5` (id: `minimax.minimax-m2.5`, name: `MiniMax M2.5`, modality: `MiniMaxText`)
+    - All models use temperature [0, 1] default 1, maxTokens [1, 8192] default 8192, topP [0, 1] default 1, topK not supported, stopSequences not supported
+    - Include the standard license header and `#if canImport(FoundationEssentials)` import guard
+    - Follow the pattern of `Sources/BedrockService/Models/xAI/xAIBedrockModels.swift`
+    - _Requirements: 1.1–1.4, 2.1–2.3, 3.1–3.3, 4.1–4.5, 9.1, 9.2_
+
+  - [ ] 1.3 Add three new cases to `BedrockModel.init?(rawValue:)` in `Sources/BedrockService/Models/BedrockModel.swift`
+    - Add `case BedrockModel.minimax_m2.id: self = BedrockModel.minimax_m2`
+    - Add `case BedrockModel.minimax_m2_1.id: self = BedrockModel.minimax_m2_1`
+    - Add `case BedrockModel.minimax_m2_5.id: self = BedrockModel.minimax_m2_5`
+    - Place them in a `// minimax` section after the `// xai` section and before `// stability`
+    - _Requirements: 1.5, 1.6, 2.4, 3.4_
+
+- [ ] 2. Checkpoint — Ensure project builds
+  - Run `swift build` to verify the new files compile without errors.
+
+- [ ] 3. Add model tests
+  - [ ] 3.1 Create `Tests/Messages/MiniMaxMessagesModelTests.swift` with model definition and modality tests
+    - Test all 3 model IDs are correct (`minimax.minimax-m2`, `minimax.minimax-m2.1`, `minimax.minimax-m2.5`)
+    - Test all 3 model names are correct (`MiniMax M2`, `MiniMax M2.1`, `MiniMax M2.5`)
+    - Test `hasMessagesModality()` returns true for all 3 models
+    - Test `hasChatCompletionsModality()` returns true for all 3 models
+    - Test `hasTextModality()` returns false for all 3 models
+    - Test `hasConverseModality()` returns false for all 3 models
+    - Test `hasResponsesModality()` returns false for all 3 models
+    - Test `hasImageModality()` returns false for all 3 models
+    - Test `getMessagesPath()` returns `/anthropic/v1/messages` for all 3 models
+    - Test `getChatCompletionsPath()` returns `/v1/chat/completions` for all 3 models
+    - Test `BedrockModel(rawValue:)` resolves all 3 models
+    - Test `BedrockModel(rawValue:)` returns nil for unknown IDs
+    - Test `getTextModality()` throws for all 3 models
+    - Test `getResponsesModality()` throws for all 3 models
+    - Test cross-region inference returns plain model ID (no prefix)
+    - Use Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`)
+    - Follow the pattern of `Tests/Messages/MessagesModelTests.swift`
+    - _Requirements: 1.1–3.4, 4.1–4.5, 5.1–5.9, 8.1, 8.2_
+
+  - [ ] 3.2 Create `Tests/Messages/MiniMaxMessagesServiceTests.swift` with service integration tests
+    - Test `createMessage` with MiniMax M2 model returns correct output using `MockBedrockMantleMessagesClient`
+    - Test `createMessage` with MiniMax M2.5 model returns correct output
+    - Test `createMessage` throws `invalidModality` for model without MessagesModality (e.g., `.nova_micro`)
+    - Follow the pattern of `Tests/Messages/MessagesServiceTests.swift`
+    - _Requirements: 6.1, 6.2, 6.3_
+
+  - [ ] 3.3 Create `Tests/ChatCompletions/MiniMaxChatCompletionsServiceTests.swift` with Chat Completions integration tests
+    - Test `completeChatCompletion` with MiniMax M2 model returns correct output using `MockBedrockMantleChatCompletionsClient`
+    - Test `completeChatCompletion` with MiniMax M2.5 model returns correct output
+    - Test `completeChatCompletion` throws `invalidModality` for model without ChatCompletionsModality
+    - Follow the pattern of `Tests/ChatCompletions/ChatCompletionsServiceTests.swift`
+    - _Requirements: 7.1, 7.2, 7.3_
+
+- [ ] 4. Checkpoint — Ensure all tests pass
+  - Run `swift test` to verify all tests pass.
+
+- [ ] 5. Add property-based tests
+  - [ ] 5.1 Write property test: Unknown raw values resolve to nil
+    - **Property 1: Unknown raw values resolve to nil**
+    - Generate 100 random UUID strings, verify all return nil from `BedrockModel(rawValue:)`
+    - Tag with `// Feature: minimax-model-support, Property 1: Unknown raw values resolve to nil`
+    - Add to `Tests/Messages/MiniMaxMessagesModelTests.swift`
+    - **Validates: Requirements 1.6**
+
+  - [ ] 5.2 Write property test: MiniMax models resolve from rawValue round-trip
+    - **Property 2: MiniMax models resolve from rawValue round-trip**
+    - Verify all 3 MiniMax model IDs resolve to non-nil instances with matching `id` property
+    - Tag with `// Feature: minimax-model-support, Property 2: rawValue round-trip`
+    - Add to `Tests/Messages/MiniMaxMessagesModelTests.swift`
+    - **Validates: Requirements 1.5, 2.4, 3.4**
+
+  - [ ] 5.3 Write property test: MiniMax models have consistent messages path
+    - **Property 3: MiniMax models have consistent messages path**
+    - Verify all 3 models return `/anthropic/v1/messages` from `getMessagesModality().getMessagesPath()`
+    - Tag with `// Feature: minimax-model-support, Property 3: Consistent messages path`
+    - Add to `Tests/Messages/MiniMaxMessagesModelTests.swift`
+    - **Validates: Requirements 1.3, 2.2, 3.2, 6.1**
+
+  - [ ] 5.4 Write property test: MiniMax models have consistent chat completions path
+    - **Property 4: MiniMax models have consistent chat completions path**
+    - Verify all 3 models return `/v1/chat/completions` from `getChatCompletionsModality().getChatCompletionsPath()`
+    - Tag with `// Feature: minimax-model-support, Property 4: Consistent chat completions path`
+    - Add to `Tests/Messages/MiniMaxMessagesModelTests.swift`
+    - **Validates: Requirements 1.4, 2.3, 3.3, 7.1**
+
+  - [ ] 5.5 Write property test: MiniMax models do not have unsupported modalities
+    - **Property 5: MiniMax models do not have unsupported modalities**
+    - Verify all 4 unsupported modality checks return false for all 3 models (`hasTextModality`, `hasConverseModality`, `hasResponsesModality`, `hasImageModality`)
+    - Tag with `// Feature: minimax-model-support, Property 5: No unsupported modalities`
+    - Add to `Tests/Messages/MiniMaxMessagesModelTests.swift`
+    - **Validates: Requirements 5.3, 5.4, 5.5, 5.6**
+
+  - [ ] 5.6 Write property test: Cross-region inference returns plain model ID
+    - **Property 6: Cross-region inference returns plain model ID**
+    - Verify all 3 models across multiple regions return the plain model ID without prefix
+    - Tag with `// Feature: minimax-model-support, Property 6: Plain model ID for cross-region`
+    - Add to `Tests/Messages/MiniMaxMessagesModelTests.swift`
+    - **Validates: Requirements 8.1, 8.2**
+
+- [ ] 6. Checkpoint — Ensure all tests pass
+  - Run `swift test` to verify all tests pass including property-based tests.
+
+- [ ] 7. Create Messages example project
+  - [ ] 7.1 Create `Examples/minimax-messages/Package.swift`
+    - Use swift-tools-version 6.0 with macOS 15 / iOS 18 / tvOS 18 platforms
+    - Define executable target `MiniMaxMessages` depending on `BedrockService` and `swift-log`
+    - Use local path dependency (`../..`) for development, with commented-out production URL
+    - Follow the exact pattern of `Examples/anthropic-messages/Package.swift`
+    - _Requirements: 10.1_
+
+  - [ ] 7.2 Create `Examples/minimax-messages/Sources/MiniMaxMessages.swift`
+    - Create a `@main struct Main` with a `static func main() async throws`
+    - Demonstrate the Messages API via bedrock-mantle using `createMessage` with `.minimax_m2`
+    - Support both API key (`AWS_BEARER_TOKEN_BEDROCK` env var) and SigV4 authentication
+    - Demonstrate a multi-turn conversation (at least 2 turns)
+    - Use region `.useast1`
+    - Print the prompt, response text, and usage information
+    - Include doc comments explaining MiniMax uses the Anthropic Messages path on bedrock-mantle
+    - Follow the code style and structure of `Examples/anthropic-messages/Sources/Messages.swift`
+    - _Requirements: 10.2, 10.3, 10.4, 10.5_
+
+- [ ] 8. Create Chat Completions example project
+  - [ ] 8.1 Create `Examples/minimax-chatcompletions/Package.swift`
+    - Use swift-tools-version 6.0 with macOS 15 / iOS 18 / tvOS 18 platforms
+    - Define executable target `MiniMaxChatCompletions` depending on `BedrockService` and `swift-log`
+    - Use local path dependency (`../..`) for development, with commented-out production URL
+    - Follow the exact pattern of `Examples/xai-grok/Package.swift`
+    - _Requirements: 11.1_
+
+  - [ ] 8.2 Create `Examples/minimax-chatcompletions/Sources/MiniMaxChatCompletions.swift`
+    - Create a `@main struct Main` with a `static func main() async throws`
+    - Demonstrate the Chat Completions API via bedrock-mantle using `completeChatCompletion` with `.minimax_m2`
+    - Support both API key (`AWS_BEARER_TOKEN_BEDROCK` env var) and SigV4 authentication
+    - Use region `.useast1`
+    - Print the prompt, response text, and usage information
+    - Include doc comments explaining MiniMax supports Chat Completions on bedrock-mantle
+    - Follow the code style and structure of `Examples/xai-grok/Sources/Grok.swift`
+    - _Requirements: 11.2, 11.3, 11.4_
+
+- [ ] 9. Add both examples to CI
+  - [ ] 9.1 Add `'minimax-messages'` and `'minimax-chatcompletions'` to the examples list in `.github/workflows/pull_request.yml`
+    - Add both entries to the JSON array in the `examples:` parameter of the integration tests job
+    - This ensures both examples compile in CI (CI runs `swift build` on each example)
+    - _Requirements: 10.6, 11.5_
+
+- [ ] 10. Final checkpoint — Ensure all tests pass and examples compile
+  - Run `swift test` for the library and `swift build` in both `Examples/minimax-messages/` and `Examples/minimax-chatcompletions/` to verify everything works.
+
+## Notes
+
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The project uses Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) — not XCTest
+- The existing `MockBedrockMantleMessagesClient` (from `Tests/Mock/`) handles mock responses for `createMessage`
+- The existing `MockBedrockMantleChatCompletionsClient` handles mock responses for `completeChatCompletion`
+- No new mocks are needed — MiniMax reuses the existing Messages and Chat Completions mock infrastructure
+- Run SPM commands (`swift build`, `swift test`) sequentially — never in parallel
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "1.2"] },
+    { "id": 1, "tasks": ["1.3"] },
+    { "id": 2, "tasks": ["3.1", "3.2", "3.3"] },
+    { "id": 3, "tasks": ["5.1", "5.2", "5.3", "5.4", "5.5", "5.6"] },
+    { "id": 4, "tasks": ["7.1", "7.2", "8.1", "8.2"] },
+    { "id": 5, "tasks": ["9.1"] }
+  ]
+}
+```

--- a/Examples/minimax/Package.swift
+++ b/Examples/minimax/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MiniMax",
+    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18)],
+    products: [
+        .executable(name: "MiniMaxChatCompletions", targets: ["MiniMaxChatCompletions"])
+    ],
+    dependencies: [
+        // for production use, uncomment the following line
+        // .package(url: "https://github.com/build-on-aws/swift-bedrock-library.git", branch: "main"),
+
+        // for local development, use the following line
+        .package(name: "swift-bedrock-library", path: "../.."),
+
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MiniMaxChatCompletions",
+            dependencies: [
+                .product(name: "BedrockService", package: "swift-bedrock-library"),
+                .product(name: "Logging", package: "swift-log"),
+            ],
+            path: "Sources/ChatCompletions"
+        )
+    ]
+)

--- a/Examples/minimax/Sources/ChatCompletions/MiniMaxChatCompletions.swift
+++ b/Examples/minimax/Sources/ChatCompletions/MiniMaxChatCompletions.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import BedrockService
+import Foundation
+import Logging
+
+/// Demonstrates MiniMax text generation via the OpenAI Chat Completions API on bedrock-mantle.
+///
+/// MiniMax models support the Chat Completions format at `/v1/chat/completions`.
+/// This example shows text generation using `completeChatCompletion`.
+@main
+struct Main {
+    static func main() async throws {
+        do {
+            try await Main.chatCompletions()
+        } catch {
+            print("Error:\n\(error)")
+        }
+    }
+
+    static func chatCompletions() async throws {
+        var logger = Logger(label: "MiniMaxChatCompletions")
+        logger.logLevel = .debug
+
+        print("MiniMax Chat Completions API via bedrock-mantle")
+        print("================================================")
+        print()
+        print("Choose authentication method:")
+        print("  1. API Key (set AWS_BEARER_TOKEN_BEDROCK environment variable)")
+        print("  2. SigV4 (uses default AWS credential provider chain)")
+        print()
+        print("Enter 1 or 2: ", terminator: "")
+
+        let choice = readLine()?.trimmingCharacters(in: .whitespaces) ?? "1"
+
+        let authentication: BedrockAuthentication
+        switch choice {
+        case "2":
+            print("Using SigV4 with default credential provider chain")
+            authentication = .default
+        default:
+            guard let apiKey = ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] else {
+                print("Error: Set AWS_BEARER_TOKEN_BEDROCK environment variable")
+                print("Create an API key at: https://console.aws.amazon.com/bedrock/home#/api-keys")
+                return
+            }
+            print("Using API Key authentication")
+            authentication = .apiKey(key: apiKey)
+        }
+
+        let bedrock = try await BedrockService(
+            region: .useast1,
+            logger: logger
+        )
+
+        let prompt = "Explain the difference between a compiler and an interpreter in two sentences."
+
+        print()
+        print("--- Chat Completions API ---")
+        print("Prompt: \(prompt)")
+        print()
+
+        let response = try await bedrock.completeChatCompletion(
+            prompt,
+            with: .minimax_m2,
+            authentication: authentication
+        )
+
+        print("Response: \(response.text)")
+        print(
+            "Usage: \(response.usage.promptTokens) prompt + \(response.usage.completionTokens) completion = \(response.usage.totalTokens) total tokens"
+        )
+    }
+}

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -146,6 +146,10 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
         case BedrockModel.gemma3_4b_it.id: self = BedrockModel.gemma3_4b_it
         // xai
         case BedrockModel.grok_4_3.id: self = BedrockModel.grok_4_3
+        // minimax
+        case BedrockModel.minimax_m2.id: self = BedrockModel.minimax_m2
+        case BedrockModel.minimax_m2_1.id: self = BedrockModel.minimax_m2_1
+        case BedrockModel.minimax_m2_5.id: self = BedrockModel.minimax_m2_5
         // stability
         case BedrockModel.stable_image_core.id: self = BedrockModel.stable_image_core
         case BedrockModel.stable_image_ultra.id: self = BedrockModel.stable_image_ultra

--- a/Sources/BedrockService/Models/MiniMax/MiniMax.swift
+++ b/Sources/BedrockService/Models/MiniMax/MiniMax.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+struct MiniMaxText: ChatCompletionsModality {
+    let parameters: TextGenerationParameters
+
+    func getName() -> String { "MiniMax Text Generation" }
+    func getChatCompletionsPath() -> String { "/v1/chat/completions" }
+    func getTextGenerationParameters() -> TextGenerationParameters { parameters }
+}

--- a/Sources/BedrockService/Models/MiniMax/MiniMaxBedrockModels.swift
+++ b/Sources/BedrockService/Models/MiniMax/MiniMaxBedrockModels.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2.html
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-1.html
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html
+
+extension BedrockModel {
+    public static let minimax_m2: BedrockModel = BedrockModel(
+        id: "minimax.minimax-m2",
+        name: "MiniMax M2",
+        modality: MiniMaxText(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8_192, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+
+    public static let minimax_m2_1: BedrockModel = BedrockModel(
+        id: "minimax.minimax-m2.1",
+        name: "MiniMax M2.1",
+        modality: MiniMaxText(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8_192, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+
+    public static let minimax_m2_5: BedrockModel = BedrockModel(
+        id: "minimax.minimax-m2.5",
+        name: "MiniMax M2.5",
+        modality: MiniMaxText(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 8_192, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 1),
+                topK: Parameter.notSupported(.topK),
+                stopSequences: StopSequenceParams.notSupported(),
+                maxPromptSize: nil
+            )
+        )
+    )
+}

--- a/Tests/ChatCompletions/MiniMaxChatCompletionsServiceTests.swift
+++ b/Tests/ChatCompletions/MiniMaxChatCompletionsServiceTests.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AwsCommonRuntimeKit
+import Testing
+
+@testable import BedrockService
+
+@Suite("MiniMax Chat Completions Service Tests")
+struct MiniMaxChatCompletionsServiceTests {
+    let bedrock: BedrockService
+
+    init() async throws {
+        CommonRuntimeKit.initialize()
+        self.bedrock = try await BedrockService(
+            region: .useast1,
+            bedrockClient: MockBedrockClient(),
+            bedrockRuntimeClient: MockBedrockRuntimeClient()
+        )
+    }
+
+    @Test("completeChatCompletion with MiniMax M2 returns correct output")
+    func completeChatCompletionMiniMaxM2() async throws {
+        let output = try await bedrock.completeChatCompletion(
+            "Hello from MiniMax",
+            with: .minimax_m2,
+            authentication: .apiKey(key: "test-key"),
+            mantleClient: MockBedrockMantleChatCompletionsClient()
+        )
+
+        #expect(output.text == "Mock completion for: Hello from MiniMax")
+        #expect(output.model == "minimax.minimax-m2")
+        #expect(output.id == "chatcmpl-mock")
+        #expect(output.usage.promptTokens == 5)
+        #expect(output.usage.completionTokens == 10)
+        #expect(output.usage.totalTokens == 15)
+    }
+
+    @Test("completeChatCompletion with MiniMax M2.5 returns correct output")
+    func completeChatCompletionMiniMaxM2_5() async throws {
+        let output = try await bedrock.completeChatCompletion(
+            "Hello from M2.5",
+            with: .minimax_m2_5,
+            authentication: .apiKey(key: "test-key"),
+            mantleClient: MockBedrockMantleChatCompletionsClient()
+        )
+
+        #expect(output.text == "Mock completion for: Hello from M2.5")
+        #expect(output.model == "minimax.minimax-m2.5")
+    }
+
+    @Test("completeChatCompletion with MiniMax M2.1 returns correct output")
+    func completeChatCompletionMiniMaxM2_1() async throws {
+        let output = try await bedrock.completeChatCompletion(
+            "Hello from M2.1",
+            with: .minimax_m2_1,
+            authentication: .apiKey(key: "test-key"),
+            mantleClient: MockBedrockMantleChatCompletionsClient()
+        )
+
+        #expect(output.text == "Mock completion for: Hello from M2.1")
+        #expect(output.model == "minimax.minimax-m2.1")
+    }
+}

--- a/Tests/ChatCompletions/MiniMaxModelTests.swift
+++ b/Tests/ChatCompletions/MiniMaxModelTests.swift
@@ -1,0 +1,277 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Bedrock Library open source project
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates
+//                    and the Swift Bedrock Library project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Bedrock Library project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import BedrockService
+
+@Suite("MiniMax Model Tests")
+struct MiniMaxModelTests {
+
+    // MARK: - Model IDs and Names
+
+    @Test("MiniMax M2 has correct model ID")
+    func minimaxM2ModelId() {
+        #expect(BedrockModel.minimax_m2.id == "minimax.minimax-m2")
+    }
+
+    @Test("MiniMax M2 has correct name")
+    func minimaxM2ModelName() {
+        #expect(BedrockModel.minimax_m2.name == "MiniMax M2")
+    }
+
+    @Test("MiniMax M2.1 has correct model ID")
+    func minimaxM2_1ModelId() {
+        #expect(BedrockModel.minimax_m2_1.id == "minimax.minimax-m2.1")
+    }
+
+    @Test("MiniMax M2.1 has correct name")
+    func minimaxM2_1ModelName() {
+        #expect(BedrockModel.minimax_m2_1.name == "MiniMax M2.1")
+    }
+
+    @Test("MiniMax M2.5 has correct model ID")
+    func minimaxM2_5ModelId() {
+        #expect(BedrockModel.minimax_m2_5.id == "minimax.minimax-m2.5")
+    }
+
+    @Test("MiniMax M2.5 has correct name")
+    func minimaxM2_5ModelName() {
+        #expect(BedrockModel.minimax_m2_5.name == "MiniMax M2.5")
+    }
+
+    // MARK: - hasChatCompletionsModality
+
+    @Test("All MiniMax models have chat completions modality")
+    func allMiniMaxHaveChatCompletionsModality() {
+        #expect(BedrockModel.minimax_m2.hasChatCompletionsModality())
+        #expect(BedrockModel.minimax_m2_1.hasChatCompletionsModality())
+        #expect(BedrockModel.minimax_m2_5.hasChatCompletionsModality())
+    }
+
+    // MARK: - Unsupported modalities
+
+    @Test("All MiniMax models do not have messages modality")
+    func allMiniMaxNoMessagesModality() {
+        #expect(!BedrockModel.minimax_m2.hasMessagesModality())
+        #expect(!BedrockModel.minimax_m2_1.hasMessagesModality())
+        #expect(!BedrockModel.minimax_m2_5.hasMessagesModality())
+    }
+
+    @Test("All MiniMax models do not have text modality")
+    func allMiniMaxNoTextModality() {
+        #expect(!BedrockModel.minimax_m2.hasTextModality())
+        #expect(!BedrockModel.minimax_m2_1.hasTextModality())
+        #expect(!BedrockModel.minimax_m2_5.hasTextModality())
+    }
+
+    @Test("All MiniMax models do not have converse modality")
+    func allMiniMaxNoConverseModality() {
+        #expect(!BedrockModel.minimax_m2.hasConverseModality())
+        #expect(!BedrockModel.minimax_m2_1.hasConverseModality())
+        #expect(!BedrockModel.minimax_m2_5.hasConverseModality())
+    }
+
+    @Test("All MiniMax models do not have responses modality")
+    func allMiniMaxNoResponsesModality() {
+        #expect(!BedrockModel.minimax_m2.hasResponsesModality())
+        #expect(!BedrockModel.minimax_m2_1.hasResponsesModality())
+        #expect(!BedrockModel.minimax_m2_5.hasResponsesModality())
+    }
+
+    @Test("All MiniMax models do not have image modality")
+    func allMiniMaxNoImageModality() {
+        #expect(!BedrockModel.minimax_m2.hasImageModality())
+        #expect(!BedrockModel.minimax_m2_1.hasImageModality())
+        #expect(!BedrockModel.minimax_m2_5.hasImageModality())
+    }
+
+    // MARK: - getChatCompletionsPath
+
+    @Test("All MiniMax models use /v1/chat/completions path")
+    func allMiniMaxChatCompletionsPath() throws {
+        let modalityM2 = try BedrockModel.minimax_m2.getChatCompletionsModality()
+        #expect(modalityM2.getChatCompletionsPath() == "/v1/chat/completions")
+
+        let modalityM2_1 = try BedrockModel.minimax_m2_1.getChatCompletionsModality()
+        #expect(modalityM2_1.getChatCompletionsPath() == "/v1/chat/completions")
+
+        let modalityM2_5 = try BedrockModel.minimax_m2_5.getChatCompletionsModality()
+        #expect(modalityM2_5.getChatCompletionsPath() == "/v1/chat/completions")
+    }
+
+    // MARK: - getMessagesModality throws
+
+    @Test("getMessagesModality throws for all MiniMax models")
+    func allMiniMaxGetMessagesModalityThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.minimax_m2.getMessagesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.minimax_m2_1.getMessagesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.minimax_m2_5.getMessagesModality()
+        }
+    }
+
+    // MARK: - BedrockModel(rawValue:)
+
+    @Test("MiniMax M2 is resolvable from rawValue")
+    func minimaxM2RawValue() {
+        let model = BedrockModel(rawValue: "minimax.minimax-m2")
+        #expect(model != nil)
+        #expect(model?.name == "MiniMax M2")
+    }
+
+    @Test("MiniMax M2.1 is resolvable from rawValue")
+    func minimaxM2_1RawValue() {
+        let model = BedrockModel(rawValue: "minimax.minimax-m2.1")
+        #expect(model != nil)
+        #expect(model?.name == "MiniMax M2.1")
+    }
+
+    @Test("MiniMax M2.5 is resolvable from rawValue")
+    func minimaxM2_5RawValue() {
+        let model = BedrockModel(rawValue: "minimax.minimax-m2.5")
+        #expect(model != nil)
+        #expect(model?.name == "MiniMax M2.5")
+    }
+
+    @Test("Unknown model IDs return nil from rawValue initializer")
+    func unknownRawValueReturnsNil() {
+        #expect(BedrockModel(rawValue: "minimax.minimax-m3") == nil)
+        #expect(BedrockModel(rawValue: "minimax.unknown") == nil)
+        #expect(BedrockModel(rawValue: "") == nil)
+    }
+
+    // MARK: - getTextModality throws
+
+    @Test("getTextModality throws for all MiniMax models")
+    func allMiniMaxGetTextModalityThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.minimax_m2.getTextModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.minimax_m2_1.getTextModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.minimax_m2_5.getTextModality()
+        }
+    }
+
+    // MARK: - getResponsesModality throws
+
+    @Test("getResponsesModality throws for all MiniMax models")
+    func allMiniMaxGetResponsesModalityThrows() {
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.minimax_m2.getResponsesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.minimax_m2_1.getResponsesModality()
+        }
+        #expect(throws: BedrockLibraryError.self) {
+            _ = try BedrockModel.minimax_m2_5.getResponsesModality()
+        }
+    }
+
+    // MARK: - Cross-region inference returns plain ID
+
+    @Test("Cross-region inference returns plain model ID (no prefix)")
+    func crossRegionReturnsPlainId() {
+        let idM2 = BedrockModel.minimax_m2.getModelIdWithCrossRegionInferencePrefix(region: .useast1)
+        #expect(idM2 == "minimax.minimax-m2")
+
+        let idM2_1 = BedrockModel.minimax_m2_1.getModelIdWithCrossRegionInferencePrefix(region: .euwest1)
+        #expect(idM2_1 == "minimax.minimax-m2.1")
+
+        let idM2_5 = BedrockModel.minimax_m2_5.getModelIdWithCrossRegionInferencePrefix(region: .apnortheast1)
+        #expect(idM2_5 == "minimax.minimax-m2.5")
+    }
+
+    // MARK: - Parameter defaults
+
+    @Test("MiniMax parameter defaults match model cards")
+    func minimaxParameterDefaults() throws {
+        let modality = try BedrockModel.minimax_m2.getChatCompletionsModality()
+        let params = modality.getTextGenerationParameters()
+        #expect(params.temperature.defaultValue == 1)
+        #expect(params.temperature.minValue == 0)
+        #expect(params.temperature.maxValue == 1)
+        #expect(params.topP.defaultValue == 1)
+        #expect(params.topP.minValue == 0)
+        #expect(params.topP.maxValue == 1)
+        #expect(params.maxTokens.defaultValue == 8_192)
+        #expect(params.maxTokens.minValue == 1)
+        #expect(params.maxTokens.maxValue == 8_192)
+        #expect(!params.topK.isSupported)
+    }
+
+    // MARK: - Property-Based Tests
+
+    // Feature: minimax-model-support, Property 1: Unknown raw values resolve to nil
+    @Test("Unknown raw values resolve to nil", arguments: (0..<100).map { _ in UUID().uuidString })
+    func unknownRawValuesResolveToNil(randomId: String) {
+        #expect(BedrockModel(rawValue: randomId) == nil)
+    }
+
+    // Feature: minimax-model-support, Property 2: rawValue round-trip
+    @Test(
+        "MiniMax model IDs resolve from rawValue",
+        arguments: ["minimax.minimax-m2", "minimax.minimax-m2.1", "minimax.minimax-m2.5"]
+    )
+    func rawValueRoundTrip(modelId: String) {
+        let model = BedrockModel(rawValue: modelId)
+        #expect(model != nil)
+        #expect(model?.id == modelId)
+    }
+
+    // Feature: minimax-model-support, Property 3: Consistent chat completions path
+    @Test(
+        "All MiniMax models have consistent chat completions path",
+        arguments: [BedrockModel.minimax_m2, BedrockModel.minimax_m2_1, BedrockModel.minimax_m2_5]
+    )
+    func consistentChatCompletionsPath(model: BedrockModel) throws {
+        let modality = try model.getChatCompletionsModality()
+        #expect(modality.getChatCompletionsPath() == "/v1/chat/completions")
+    }
+
+    // Feature: minimax-model-support, Property 4: No unsupported modalities
+    @Test(
+        "MiniMax models do not have unsupported modalities",
+        arguments: [BedrockModel.minimax_m2, BedrockModel.minimax_m2_1, BedrockModel.minimax_m2_5]
+    )
+    func noUnsupportedModalities(model: BedrockModel) {
+        #expect(!model.hasTextModality())
+        #expect(!model.hasConverseModality())
+        #expect(!model.hasResponsesModality())
+        #expect(!model.hasMessagesModality())
+        #expect(!model.hasImageModality())
+    }
+
+    // Feature: minimax-model-support, Property 5: Plain model ID for cross-region
+    @Test(
+        "Cross-region inference returns plain model ID for all regions",
+        arguments: [BedrockModel.minimax_m2, BedrockModel.minimax_m2_1, BedrockModel.minimax_m2_5]
+    )
+    func plainModelIdForCrossRegion(model: BedrockModel) {
+        let regions: [Region] = [.useast1, .uswest2, .euwest1, .eucentral1, .apnortheast1]
+        for region in regions {
+            let result = model.getModelIdWithCrossRegionInferencePrefix(region: region)
+            #expect(result == model.id)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add support for three MiniMax models via the Chat Completions API on bedrock-mantle.

### Models added
- `minimax_m2` — MiniMax M2 (1M context, 8K max output)
- `minimax_m2_1` — MiniMax M2.1 (196K context, 8K max output)
- `minimax_m2_5` — MiniMax M2.5 (196K context, 8K max output)

### API support
- **Chat Completions** (`completeChatCompletion`) at `/v1/chat/completions` via bedrock-mantle
- No cross-region inference (in-region only)
- No Responses, Messages, Converse, or InvokeModel support

### Changes
- `Sources/BedrockService/Models/MiniMax/MiniMax.swift` — `MiniMaxText: ChatCompletionsModality` struct
- `Sources/BedrockService/Models/MiniMax/MiniMaxBedrockModels.swift` — three model constants
- `Sources/BedrockService/Models/BedrockModel.swift` — rawValue switch cases
- `Tests/ChatCompletions/MiniMaxModelTests.swift` — model definition and property-based tests
- `Tests/ChatCompletions/MiniMaxChatCompletionsServiceTests.swift` — service integration tests
- `Examples/minimax/` — example project with `MiniMaxChatCompletions` target
- `.github/workflows/pull_request.yml` — added `minimax` to CI examples

### Testing
- All 361 tests pass
- Example builds and runs successfully against live bedrock-mantle endpoint

### References
- [Model card M2](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2.html)
- [Model card M2.1](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-1.html)
- [Model card M2.5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html)