### PR TITLE
Add Claude Opus 5 model support

### DIFF
--- a/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
+++ b/Sources/BedrockService/Models/Anthropic/AnthropicBedrockModels.swift
@@ -315,4 +315,20 @@ extension BedrockModel {
             maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
         )
     )
+    public static let claude_opus_v5: BedrockModel = BedrockModel(
+        id: "anthropic.claude-opus-5",
+        name: "Claude Opus 5",
+        modality: Claude_Fable_v5(
+            parameters: TextGenerationParameters(
+                temperature: Parameter(.temperature, minValue: 0, maxValue: 1, defaultValue: 1),
+                maxTokens: Parameter(.maxTokens, minValue: 1, maxValue: 128_000, defaultValue: 8_192),
+                topP: Parameter(.topP, minValue: 0, maxValue: 1, defaultValue: 0.999),
+                topK: Parameter(.topK, minValue: 0, maxValue: 500, defaultValue: 0),
+                stopSequences: StopSequenceParams(maxSequences: 8191, defaultValue: []),
+                maxPromptSize: 1_000_000
+            ),
+            features: [.textGeneration, .systemPrompts, .document, .vision, .toolUse, .reasoning, .structuredOutput],
+            maxReasoningTokens: Parameter(.maxReasoningTokens, minValue: 1_024, maxValue: 8_191, defaultValue: 4_096)
+        )
+    )
 }

--- a/Sources/BedrockService/Models/BedrockModel.swift
+++ b/Sources/BedrockService/Models/BedrockModel.swift
@@ -91,6 +91,8 @@ public struct BedrockModel: Hashable, Sendable, Equatable, RawRepresentable {
             self = BedrockModel.claude_opus_v4_8
         case BedrockModel.claude_fable_v5.id:
             self = BedrockModel.claude_fable_v5
+        case BedrockModel.claude_opus_v5.id:
+            self = BedrockModel.claude_opus_v5
         // titan
         case BedrockModel.titan_text_g1_premier.id:
             self = BedrockModel.titan_text_g1_premier


### PR DESCRIPTION
## Summary

Add support for Claude Opus 5 (anthropic.claude-opus-5).

### Model details
- **Model ID**: `anthropic.claude-opus-5`
- **Context window**: 1M tokens
- **Max output**: 128K tokens
- **Reasoning**: Supported (adaptive thinking on by default)
- **Knowledge cutoff**: May 2026
- **Cross-region**: Global (`global.anthropic.claude-opus-5`)

### APIs supported
- Invoke + Converse (bedrock-runtime)
- Messages API (bedrock-mantle at `/anthropic/v1/messages`)

### Features
Text, vision, tool use, reasoning, structured output, system prompts, document

### Testing
- All 361 tests pass
- Testable with existing `anthropic-messages` example using `.claude_opus_v5`

### Reference
- [Model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html)